### PR TITLE
Fixed watershed track creation

### DIFF
--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -333,6 +333,7 @@ class TrackReview:
         # Pull the label that is being split and find a new valid label
         current_label = self.mode.label_1
         new_label = self.num_tracks + 1
+        self.num_tracks += 1
 
         # Locally store the frames to work on
         img_raw = self.raw[self.current_frame]


### PR DESCRIPTION
Fixes bug where tracks created with watershed have the same ID as a track produced using the create track command when the create track command is used after watershed.

The action_new_track function, which is called when creating a new track, incremented the self.num_tracks  variable, while the action_watershed function did not. By having the action_watershed function increment self.num_tracks, the issue is resolved.