### PR TITLE
Single Frame Swap Feature

### DIFF
--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -87,6 +87,9 @@ class TrackReview:
         self.mode = Mode.none()
         self.adjustment = 0
         self.scale_factor = 1
+        self.highlight = False
+        self.highlighted_cell_one = -1
+        self.highlighted_cell_two = -1
 
         pyglet.app.run()
 
@@ -107,10 +110,18 @@ class TrackReview:
                                  label=label,
                                  frame=self.current_frame,
                                  y_location=self.y, x_location=self.x)
+                self.highlighted_cell_one = label
+                self.highlighted_cell_two = -1
+            else:
+                self.mode = Mode.none()
+                self.highlighted_cell_one = -1
+                self.highlighted_cell_two = -1
         elif self.mode.kind == "SELECTED":
             frame = self.tracked[self.current_frame]
             label = int(frame[self.y, self.x])
             if label != 0:
+                self.highlighted_cell_one = self.mode.label
+                self.highlighted_cell_two = label
                 self.mode = Mode("MULTIPLE",
                                  label_1=self.mode.label,
                                  frame_1=self.mode.frame,
@@ -120,6 +131,28 @@ class TrackReview:
                                  frame_2=self.current_frame,
                                  y2_location = self.y,
                                  x2_location = self.x)
+            else:
+                self.mode = Mode.none()
+                self.highlighted_cell_one = -1
+                self.highlighted_cell_two = -1
+        elif self.mode.kind == "MULTIPLE":
+            frame = self.tracked[self.current_frame]
+            label = int(frame[self.y, self.x])
+            if label != 0:
+                self.highlighted_cell_two = label
+                self.mode = Mode("MULTIPLE",
+                                 label_1=self.mode.label_1,
+                                 frame_1=self.mode.frame_1,
+                                 y1_location = self.mode.y1_location,
+                                 x1_location = self.mode.x1_location,
+                                 label_2=label,
+                                 frame_2=self.current_frame,
+                                 y2_location = self.y,
+                                 x2_location = self.x)
+            else:
+                self.mode = Mode.none()
+                self.highlighted_cell_one = -1
+                self.highlighted_cell_two = -1
 
     def on_mouse_scroll(self, x, y, scroll_x, scroll_y):
         if self.draw_raw:
@@ -167,6 +200,8 @@ class TrackReview:
         offset = 5 if modifiers & key.MOD_SHIFT else 1
         if symbol == key.ESCAPE:
             self.mode = Mode.none()
+            self.highlighted_cell_one = -1
+            self.highlighted_cell_two = -1
         elif symbol in {key.LEFT, key.A}:
             self.current_frame = max(self.current_frame - offset, 0)
         elif symbol in {key.RIGHT, key.D}:
@@ -200,7 +235,20 @@ class TrackReview:
             if self.mode.kind == "MULTIPLE":
                 self.mode = Mode("QUESTION",
                                  action="WATERSHED", **self.mode.info)
-
+        if symbol == key.H:
+            self.highlight = not self.highlight
+        if symbol == key.EQUAL:
+            if self.mode.kind == "SELECTED":
+                if self.highlighted_cell_one < self.num_tracks:
+                    self.highlighted_cell_one += 1
+                elif self.highlighted_cell_one == self.num_tracks:
+                    self.highlighted_cell_one = 1
+        if symbol == key.MINUS:
+            if self.mode.kind == "SELECTED":
+                if self.highlighted_cell_one > 1:
+                    self.highlighted_cell_one -= 1
+                elif self.highlighted_cell_one == 1:
+                    self.highlighted_cell_one = self.num_tracks
 
         if symbol == key.SPACE:
             if self.mode.kind == "QUESTION":
@@ -217,6 +265,8 @@ class TrackReview:
                 elif self.mode.action == "WATERSHED":
                     self.action_watershed()
                 self.mode = Mode.none()
+                self.highlighted_cell_one = -1
+                self.highlighted_cell_two = -1
 
     def get_current_frame(self):
         if self.draw_raw:
@@ -257,7 +307,18 @@ class TrackReview:
                                        multiline=True,
                                        x=5, y=5, color=[255]*4)
 
-        frame_label = pyglet.text.Label("frame: {}".format(self.current_frame),
+        highlight_text = ""
+        if self.highlight:
+            if self.highlighted_cell_two != -1:
+                highlight_text = "highlight: on\nhighlighted cell 1: {}\nhighlighted cell 2: {}".format(self.highlighted_cell_one, self.highlighted_cell_two)
+            elif self.highlighted_cell_one != -1:
+                highlight_text = "highlight: on\nhighlighted cell: {}".format(self.highlighted_cell_one)
+            else:
+                highlight_text = "highlight: on"
+        else:
+            highlight_text = "highlight: off"
+
+        frame_label = pyglet.text.Label("frame: {}\n{}".format(self.current_frame, highlight_text),
                                         font_name="monospace",
                                         anchor_x="left", anchor_y="top",
                                         width=self.sidebar_width,
@@ -270,6 +331,16 @@ class TrackReview:
 
     def draw_current_frame(self):
         frame = self.get_current_frame()
+        cmap = plt.get_cmap("cubehelix")
+        cmap.set_bad('red')
+
+        if self.highlight:
+            if self.mode.kind == "SELECTED":
+                frame = np.ma.masked_equal(frame, self.highlighted_cell_one)
+            elif self.mode.kind == "MULTIPLE":
+                frame = np.ma.masked_equal(frame, self.highlighted_cell_one)
+                frame = np.ma.masked_equal(frame, self.highlighted_cell_two)
+
         with tempfile.TemporaryFile() as file:
             if self.draw_raw:
                 plt.imsave(file, frame[:, :, 0],
@@ -280,7 +351,7 @@ class TrackReview:
                 plt.imsave(file, frame[:, :, 0],
                            vmin=0,
                            vmax=self.num_tracks + self.adjustment,
-                           cmap="cubehelix",
+                           cmap=cmap,
                            format="png")
             image = pyglet.image.load("frame.png", file)
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -469,21 +469,20 @@ class TrackReview:
         relabel(-1, self.mode.label_2)
 
     def action_single_swap(self):
-        def relabel(old_label, new_label):
-            for frame in self.tracked[self.current_frame]:
-                frame[frame == old_label] = new_label
-
-            # replace fields
-            track_new = self.tracks[new_label] = self.tracks[old_label]
-            track_new["label"] = new_label
-            del self.tracks[old_label]
-
-            for d in track_new["daughters"]:
-                self.tracks[d]["parent"] = new_label
-
-        relabel(self.mode.label_1, -1)
-        relabel(self.mode.label_2, self.mode.label_1)
-        relabel(-1, self.mode.label_2)
+        '''
+        swap annotation labels in one frame but do not change lineage info
+        '''
+        label_1 = self.mode.label_1
+        label_2 = self.mode.label_2
+        
+        frame = self.current_frame
+        
+        ann_img = self.tracked[frame]
+        ann_img = np.where(ann_img == label_1, -1, ann_img)
+        ann_img = np.where(ann_img == label_2, label_1, ann_img)
+        ann_img = np.where(ann_img == -1, label_2, ann_img)
+        
+        self.tracked[frame] = ann_img
 
     def action_parent(self):
         """

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -68,7 +68,7 @@ class TrackReview:
 
         # `label` should appear first
         self.track_keys = ["label", *sorted(set(self.tracks[1]) - {"label"})]
-        self.num_tracks = max(self.tracks) + 1
+        self.num_tracks = max(self.tracks)
 
         self.num_frames, self.height, self.width, _ = raw.shape
         self.window = pyglet.window.Window(resizable=True)
@@ -161,8 +161,8 @@ class TrackReview:
             else:
                 self.max_intensity = max(self.max_intensity - 2 * scroll_y, 2)
         else:
-            if self.num_tracks + (self.adjustment - 2 * scroll_y) >= 0:
-                self.adjustment = self.adjustment - 2 * scroll_y
+            if self.num_tracks + (self.adjustment - 1 * scroll_y) > 0:
+                self.adjustment = self.adjustment - 1 * scroll_y
 
     def on_mouse_motion(self, x, y, dx, dy):
         x -= self.sidebar_width

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -228,6 +228,9 @@ class TrackReview:
             if self.mode.kind == "MULTIPLE":
                 self.mode = Mode("QUESTION",
                                  action="SWAP", **self.mode.info)
+            elif self.mode.kind == "QUESTION" and self.mode.action == "SWAP":
+                self.action_single_swap()
+                self.mode = Mode.none()
             elif self.mode.kind is None:
                 self.mode = Mode("QUESTION",
                                  action="SAVE")
@@ -451,6 +454,23 @@ class TrackReview:
     def action_swap(self):
         def relabel(old_label, new_label):
             for frame in self.tracked:
+                frame[frame == old_label] = new_label
+
+            # replace fields
+            track_new = self.tracks[new_label] = self.tracks[old_label]
+            track_new["label"] = new_label
+            del self.tracks[old_label]
+
+            for d in track_new["daughters"]:
+                self.tracks[d]["parent"] = new_label
+
+        relabel(self.mode.label_1, -1)
+        relabel(self.mode.label_2, self.mode.label_1)
+        relabel(-1, self.mode.label_2)
+
+    def action_single_swap(self):
+        def relabel(old_label, new_label):
+            for frame in self.tracked[self.current_frame]:
                 frame[frame == old_label] = new_label
 
             # replace fields

--- a/desktop/mode.py
+++ b/desktop/mode.py
@@ -54,7 +54,7 @@ class Mode:
                 return ("\nreplace {} with ".format(self.label_2)
                         + "{}?\n {}".format(self.label_1, answer))
             elif self.action == "SWAP":
-                return ("\nswap {} & {}?\n {}".format(self.label_2, self.label_1, answer))
+                return ("\nswap {} & {}?\n {}".format(self.label_2, self.label_1, "(S=SINGLE FRAME / SPACE=ALL FRAMES / ESC=NO)"))
             elif self.action == "PARENT":
                 return ("\nmake {} a daughter of ".format(self.label_2)
                         + "{}\n {}".format(self.label_1, answer))


### PR DESCRIPTION
User can now use the swap feature to swap cells on only current frame instead of all frames. When S is pressed to call the swap feature, the prompt will ask the user to either press S again to swap for a single frame, Space to swap in all frames, or Escape to cancel.