### PR TITLE
Fixes bug with empty tracks persisting in trk file

### DIFF
--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -449,6 +449,14 @@ class TrackReview:
         if not os.path.exists(backup_file):
             shutil.copyfile(self.filename + ".trk", backup_file)
 
+        # clear any empty tracks before saving file
+        empty_tracks = []
+        for key in self.tracks:
+        	if not self.tracks[key]['frames']:
+        		empty_tracks.append(self.tracks[key]['label'])
+        for track in empty_tracks:
+        	del self.tracks[track]
+
         with tarfile.open(self.filename + ".trk", "w") as trks:
             with tempfile.NamedTemporaryFile("w") as lineage_file:
                 json.dump(self.tracks, lineage_file, indent=1)


### PR DESCRIPTION
When saving, checks if there are any tracks that do not contain any frames and deletes them. Credit to Geneva for (most) of the code :)