### PR TITLE
Feature/trk feature updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ python3 caliban.py [input file location]
 ```
 
 **Accepted file types:**
-Caliban can open .trk files or .npz files. .npz files must contain two zipped files corresponding to raw images and annotated images. If the files are not named 'raw' and 'annotated', the first file in the .npz will be opened as the raw images. Raw and annotated images must both be in 4D arrays in the shape (frames, y, x, channels or features).
+Caliban can open .trk files or .npz files. .npz files must contain two zipped files corresponding to raw images and annotated images. If the files are not named 'raw' and 'annotated' or 'X' and 'y', the first file in the .npz will be opened as the raw images. Raw and annotated images must both be in 4D arrays in the shape (frames, y, x, channels or features).
 
 ## Tools Guide
 Files can be edited using keyboard operations.
@@ -30,6 +30,8 @@ Caliban's default setting allows operations to be carried out quickly and easily
 *click* - click on a cell label to select it. Up to two cells can be selected at one time.
 
 *r* - replace: relabel all instances of a selected cell label with a second selected cell label; replaces lineage data in a trk file
+
+*r* - relabel: sequentially relabel all cells in frame, starting from 1, when no cells are selected (npz only)
 
 *c* - create: relabel selected cell with an unused label
 
@@ -62,6 +64,8 @@ Annotation mode focuses on using an adjustable brush to modify annotations on a 
 
 *x* - toggle eraser mode
 
+*p* - color picker (click on a label to change the brush value to it)
+
 
 ### Viewing Options:
 
@@ -84,7 +88,7 @@ Annotation mode focuses on using an adjustable brush to modify annotations on a 
 
 Once done, use the following key to save the changed file. 
 The tool will also save the original file in the same folder.
-In npz mode, a new npz file will be saved with a version number.
+In npz mode, a new npz file will be saved with a version number. An npz can be saved as a trk file (select "t" in response to save prompt). This will bundle together the current channel and feature of the npz along with a generated lineage file, which will contain label and frame information and empty parent/daughter entries for each cell. The new trk file can then be edited in Caliban's trk mode to add relationship information.
 
 *s* - save
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -627,7 +627,9 @@ class ZStackReview:
                 self.cell_info[feature][cell]['slices'] = ''
 
         #don't display 'frames' just 'slices' (updated on_draw)
-        self.display_info = [*sorted(set(self.cell_info[0][1]) - {'frames'})]
+        first_key = list(self.cell_info[0])[0]
+        display_info_types = self.cell_info[0][first_key]
+        self.display_info = [*sorted(set(display_info_types) - {'frames'})]
             
         self.window = pyglet.window.Window(resizable=True)
         self.window.set_minimum_size(self.width + self.sidebar_width, self.height + 20)

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -242,6 +242,9 @@ class TrackReview:
             elif self.mode.kind == "QUESTION" and self.mode.action == "SWAP":
                 self.action_single_swap()
                 self.mode = Mode.none()
+            elif self.mode.kind == "QUESTION" and self.mode.action == "NEW TRACK":
+                self.action_new_single_cell()
+                self.mode = Mode.none()
             elif self.mode.kind is None:
                 self.mode = Mode("QUESTION",
                                  action="SAVE")
@@ -413,6 +416,21 @@ class TrackReview:
         track_old["daughters"] = []
         track_old["frame_div"] = None
         track_old["capped"] = True
+
+    def action_new_single_cell(self):
+        """
+        Create new label in just one frame
+        """
+        old_label, single_frame = self.mode.label, self.mode.frame
+        new_label = self.num_tracks + 1
+
+        # replace frame labels
+        frame = self.tracked[single_frame]
+        frame[frame == old_label] = new_label
+
+        # replace fields
+        self.del_cell_info(del_label = old_label, frame = single_frame)
+        self.add_cell_info(add_label = new_label, frame = single_frame)
 
 
     def action_watershed(self):

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -300,6 +300,7 @@ class TrackReview:
         y_scale = self.window.height // self.height
         x_scale = (self.window.width - 300) // self.width
         self.scale_factor = min(y_scale, x_scale)
+        self.scale_factor = max(1, self.scale_factor)
 
     def on_key_press(self, symbol, modifiers):
         # Set scroll speed (through sequential frames) with offset
@@ -1103,6 +1104,7 @@ class ZStackReview:
         y_scale = self.window.height // self.height
         x_scale = (self.window.width - 300) // self.width
         self.scale_factor = min(y_scale, x_scale)
+        self.scale_factor = max(1, self.scale_factor)
 
     def on_key_press(self, symbol, modifiers):
         # Set scroll speed (through sequential frames) with offset

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -591,10 +591,11 @@ class TrackReview:
                 trks.add(tracked_file.name, "tracked.npy")
                 
 class ZStackReview:
-    def __init__(self, filename, raw, annotated):
+    def __init__(self, filename, raw, annotated, save_vars_mode):
         self.filename = filename
         self.raw = raw
         self.annotated = annotated
+        self.save_vars_mode = save_vars_mode
         
         self.feature = 0
         self.feature_max = self.annotated.shape[-1]
@@ -1356,7 +1357,10 @@ class ZStackReview:
                 
     def save(self):
         save_file = self.filename + "_save_version_{}.npz".format(self.save_version)
-        np.savez(save_file, raw = self.raw, annotated = self.annotated)
+        if self.save_vars_mode == 0:
+            np.savez(save_file, raw = self.raw, annotated = self.annotated)
+        else:
+            np.savez(save_file, X = self.raw, y = self.annotated)
         self.save_version += 1
 
 def consecutive(data, stepsize=1):
@@ -1492,11 +1496,17 @@ def load_npz(filename):
     try:
         raw_stack = npz['raw']
         annotation_stack = npz['annotated']
+        save_vars_mode = 0
     except:
-        raw_stack = npz[npz.files[0]]
-        annotation_stack = npz[npz.files[1]]
-        
-    return {"raw": raw_stack, "annotated": annotation_stack}
+        try:
+            raw_stack = npz['X']
+            annotation_stack = npz['y']
+            save_vars_mode = 1
+        except:
+            raw_stack = npz[npz.files[0]]
+            annotation_stack = npz[npz.files[1]]
+            save_vars_mode = 2
+    return {"raw": raw_stack, "annotated": annotation_stack, "save_vars_mode": save_vars_mode}
     
 
 def review(filename):

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1190,6 +1190,7 @@ class ZStackReview:
             if self.mode.kind == "QUESTION":
                 if self.mode.action == "SAVE":
                     self.save_as_trk()
+                    self.mode = Mode.none()
                 
         if symbol == key.P:
             if self.mode.kind is None and not self.edit_mode:

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -207,6 +207,9 @@ class TrackReview:
             self.current_frame = min(self.current_frame + offset, self.num_frames - 1)
         elif symbol == key.Z:
             self.draw_raw = not self.draw_raw
+        elif symbol == key.H:
+            self.highlight = not self.highlight
+
         else:
             self.mode_handle(symbol)
 
@@ -246,9 +249,6 @@ class TrackReview:
             if self.mode.kind == "MULTIPLE":
                 self.mode = Mode("QUESTION",
                                  action="WATERSHED", **self.mode.info)
-        #no prompt needed to toggle highlight mode
-        if symbol == key.H:
-            self.highlight = not self.highlight
         #cycle through highlighted cells
         if symbol == key.EQUAL:
             if self.mode.kind == "SELECTED":

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1067,8 +1067,6 @@ class ZStackReview:
     def on_mouse_scroll(self, x, y, scroll_x, scroll_y):
         if self.draw_raw:
             if self.max_intensity[self.channel] is None:
-                current_frame = self.get_current_frame()
-                max_val = np.max(current_frame[:,:,self.channel])
                 self.max_intensity[self.channel] = np.max(self.get_current_frame()[:,:,self.channel])
             else:
                 raw_adjust = max(int(self.max_intensity[self.channel] * 0.02), 1)

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -517,7 +517,12 @@ class TrackReview:
         track_1 = self.tracks[label_1]
         track_2 = self.tracks[label_2]
 
-        track_1["daughters"].append(label_2)
+        #add daughter but don't duplicate entry
+        daughters = track_1["daughters"].copy()
+        daughters.append(label_2)
+        daughters = np.unique(daughters).tolist()
+        track_1["daughters"] = daughters
+
         track_2["parent"] = label_1
         track_1["frame_div"] = frame_div
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1787,14 +1787,15 @@ def predict_zstack_cell_ids(img, next_img):
     for next_cell, matched_cell in enumerate(max_indices):
         
         if matched_cell not in used_cells:
-            
-            #add it to the relabeled image
-            relabeled_next = np.where(next_img == next_cell, matched_cell, relabeled_next)
-            
             #don't add background to used_cells
+            #add the matched cell to the relabeled image
             if matched_cell != 0:
+                relabeled_next = np.where(next_img == next_cell, matched_cell, relabeled_next)
+
                 used_cells = np.append(used_cells, matched_cell)
-        
+            elif matched_cell == 0:
+                pass
+
         elif matched_cell in used_cells:
             #skip that pairing, add next_cell to unmatched_cells
             unmatched_cells = np.append(unmatched_cells, next_cell)

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -739,7 +739,8 @@ class TrackReview:
 
     def action_replace(self):
         """
-        Replacing label_2 with label_1
+        Replacing label_2 with label_1. Overwrites all instances of label_2 in
+        movie, and replaces label_2 lineage information with info from label_1.
         """
         label_1, label_2 = self.mode.label_1, self.mode.label_2
 
@@ -1461,7 +1462,8 @@ class ZStackReview:
             
     def action_replace(self):
         """
-        Replacing label_2 with label_1
+        Replacing label_2 with label_1. Overwrites every label_2 in the npz
+        with label_1 and updates cell_info accordingly.
         """
         label_1, label_2 = self.mode.label_1, self.mode.label_2
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -786,7 +786,7 @@ class ZStackReview:
                 self.max_intensity[self.channel] = max(self.max_intensity[self.channel] - raw_adjust * scroll_y, 2)
                 
         else:
-            if self.num_cells[self.feature] + (self.adjustment[self.feature] - 1 * scroll_y) > 0:
+            if np.max(self.cell_ids[self.feature]) + (self.adjustment[self.feature] - 1 * scroll_y) > 0:
                 self.adjustment[self.feature] = self.adjustment[self.feature] - 1 * scroll_y
 
     def on_mouse_motion(self, x, y, dx, dy):

--- a/desktop/mode.py
+++ b/desktop/mode.py
@@ -78,6 +78,8 @@ class Mode:
                 return ("\nperform watershed to split {}?\n{}".format(self.label_1, answer))
             elif self.action == "PREDICT":
                 return ("Predict cell ids for zstack?\nS=PREDICT THIS FRAME\nSPACE=PREDICT ALL FRAMES\nESC=CANCEL PREDICTION")
+            elif self.action == "RELABEL":
+                return ("Relabel cells in this frame?\nSPACE=RELABEL\nESC=CANCEL")
         elif self.kind == "PROMPT":
             if self.action == "FILL HOLE":
                 return('\nselect hole to fill in cell {}'.format(self.label))

--- a/desktop/mode.py
+++ b/desktop/mode.py
@@ -81,6 +81,8 @@ class Mode:
         elif self.kind == "PROMPT":
             if self.action == "FILL HOLE":
                 return('\nselect hole to fill in cell {}'.format(self.label))
+            elif self.action == "PICK COLOR":
+                return('\nclick on a cell to change the brush value to that value')
 
         else:
             return ''

--- a/desktop/mode.py
+++ b/desktop/mode.py
@@ -43,13 +43,21 @@ class Mode:
             return ''
         answer = "(SPACE=YES / ESC=NO)"
 
+        try:
+            filetype = self.info['filetype']
+        except KeyError:
+            filetype = ""
+
         if self.kind == "SELECTED":
             return "\nSELECTED {}".format(self.label)
         elif self.kind == "MULTIPLE":
             return "\nSELECTED {}, {}".format(self.label_1, self.label_2)
         elif self.kind == "QUESTION":
             if self.action == "SAVE":
-                return ("\nsave current movie?\n {}".format(answer))
+                if filetype == "npz":
+                    return ("\nSave current movie?\nSPACE=SAVE\nT=SAVE AS .TRK FILE\nESC=CANCEL")
+                else:
+                    return ("\nSave current movie?\nSPACE=SAVE\nESC=CANCEL")
             elif self.action == "REPLACE":
                 return ("\nreplace {} with {}?\n {}".format(self.label_2, self.label_1, answer))
             elif self.action == "SWAP":

--- a/desktop/mode.py
+++ b/desktop/mode.py
@@ -66,7 +66,8 @@ class Mode:
             elif self.action == "PARENT":
                 return ("\nmake {} a daughter of {}?\n {}".format(self.label_2, self.label_1, answer))
             elif self.action == "NEW TRACK":
-                return ("\ncreate new track from {} on frame {}?\n {}".format(self.label, self.frame, answer) + "\n {}".format(answer))
+                return ("\ncreate new track from {} on frame {}?".format(self.label, self.frame) + 
+                    "\n {}".format("(S=SINGLE FRAME / SPACE=ALL SUBSEQUENT FRAMES / ESC=NO)"))
             elif self.action == "CREATE NEW":
                 return ("".format(self.label, self.frame)
                         + "\n {}".format("(S=SINGLE FRAME / SPACE=ALL SUBSEQUENT FRAMES / ESC=NO)"))

--- a/desktop/mode.py
+++ b/desktop/mode.py
@@ -72,7 +72,7 @@ class Mode:
                 return ("".format(self.label, self.frame)
                         + "\n {}".format("(S=SINGLE FRAME / SPACE=ALL SUBSEQUENT FRAMES / ESC=NO)"))
             elif self.action == "DELETE":
-                return ('Delete label {} in frame {}?\n{}'.format(self.label, self.frame,
+                return ('\nDelete label {} in frame {}?\n{}'.format(self.label, self.frame,
                 "SPACE = CONFIRM DELETION\nESC = CANCEL DELETION"))
             elif self.action == "WATERSHED":
                 return ("\nperform watershed to split {}?\n{}".format(self.label_1, answer))

--- a/desktop/mode.py
+++ b/desktop/mode.py
@@ -55,7 +55,7 @@ class Mode:
             elif self.action == "SWAP":
                 return ("\nswap {} & {}?\n{}".format(self.label_2, self.label_1, 
                 'SPACE = SWAP IN ALL FRAMES\nS = SWAP IN THIS FRAME ONLY\nESC = CANCEL SWAP'))
-            elif sel.action == "PARENT":
+            elif self.action == "PARENT":
                 return ("\nmake {} a daughter of {}?\n {}".format(self.label_2, self.label_1, answer))
             elif self.action == "NEW TRACK":
                 return ("\ncreate new track from {} on frame {}?\n {}".format(self.label, self.frame, answer) + "\n {}".format(answer))


### PR DESCRIPTION
Update features in both npz and trk modes.

Changes to npz mode:
- add highlight feature from trk mode
- add flexibility in opening npz files (can open npz files saved as 'X' and 'y', a common format for our lab; npz does not need to contain a cell labeled with 1 to initialize properly)
- add option to save npz with lineage info to make a trk
- add option to sequentially relabel cells in a single frame

Changes to trk mode:
- add hole fill
- add edit mode
- prevent duplicate daughters upon parent assignation
- add single frame version of action_new_track

Changes to both modes:
- clean up code with helper functions for creating or deleting cell info
- change brightness adjustment of raw image to scale to max brightness in frame instead of being a fixed value
- add color picker to edit mode
- set minimum value of self.scale_factor to 1 to prevent divide by zero bug that sometimes crashed Caliban