### PR TITLE
Upgrade Pillow version

### DIFF
--- a/browser/requirements.txt
+++ b/browser/requirements.txt
@@ -15,7 +15,7 @@ kiwisolver==1.1.0
 MarkupSafe==1.1.1
 matplotlib==3.1.0
 numpy==1.16.4
-Pillow==6.0.0
+pillow>=6.2.0
 post==2019.4.13
 public==2019.4.13
 pyparsing==2.4.0


### PR DESCRIPTION
Caliban (Browser) requirements pinned an old Pillow version with a vulnerability. Amended to requirements.txt to keep up to date.  