### PR TITLE
Consolidate browser actions to use just one POST request

### DIFF
--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -77,6 +77,7 @@ class ZStackReview:
         self.color_map = plt.get_cmap('viridis')
         self.color_map.set_bad('black')
 
+
     @property
     def readable_tracks(self):
         """

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -51,6 +51,7 @@ class ZStackReview:
         self.feature_max = self.annotated.shape[-1]
         self.channel = 0
         self.max_frames, self.height, self.width, self.channel_max = self.raw.shape
+        self.dimensions = (self.width, self.height)
 
         #create a dictionary that has frame information about each cell
         #analogous to .trk lineage but do not need relationships between cells included
@@ -63,27 +64,15 @@ class ZStackReview:
         for feature in range(self.feature_max):
             self.create_cell_info(feature)
 
-        #don't display 'frames' just 'slices' (updated on_draw)
-        first_key = list(self.cell_info[0])[0]
-        display_info_types = self.cell_info[0][first_key]
-        self.display_info = [*sorted(set(display_info_types) - {'frames'})]
-
         self.draw_raw = False
         self.max_intensity = {}
         for channel in range(self.channel_max):
             self.max_intensity[channel] = None
-        self.x = 0
-        self.y = 0
-        self.adjustment = {}
-        for feature in range(self.feature_max):
-            self.adjustment[feature] = 0
+
         self.dtype_raw = self.raw.dtype
         self.scale_factor = 2
 
-        self.hole_fill_seed = None
-        self.fill_label = None
         self.save_version = 0
-        self.dimensions = self.raw.shape[1:3][::-1]
 
         self.color_map = plt.get_cmap('viridis')
         self.color_map.set_bad('black')
@@ -118,7 +107,7 @@ class ZStackReview:
             frame = np.ma.masked_equal(frame, 0)
             return pngify(imgarr=frame,
                          vmin=0,
-                         vmax=self.num_cells[self.feature] + self.adjustment[self.feature],
+                         vmax=self.num_cells[self.feature],
                          cmap=self.color_map)
 
     def get_array(self, frame):
@@ -566,14 +555,6 @@ class TrackReview:
         self.color_map.set_bad('black')
 
         self.current_frame = 0
-
-        self.x = 0
-        self.y = 0
-
-        self.edit_mode = False
-        self.hole_fill_seed = None
-        self.fill_label = None
-        self.brush_view = np.zeros(self.tracked[self.current_frame].shape)
 
 
     @property

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -77,6 +77,8 @@ class ZStackReview:
         self.color_map = plt.get_cmap('viridis')
         self.color_map.set_bad('black')
 
+        self.frames_changed = False
+        self.info_changed = False
 
     @property
     def readable_tracks(self):
@@ -193,12 +195,17 @@ class ZStackReview:
         img_ann = self.annotated[frame,:,:,self.feature]
         contig_cell = flood(image = img_ann, seed_point = (int(y_location/self.scale_factor), int(x_location/self.scale_factor)))
         img_trimmed = np.where(np.logical_and(np.invert(contig_cell), img_ann == label), 0, img_ann)
-        self.annotated[frame,:,:,self.feature] = img_trimmed
 
+        #check if image changed
+        comparison = np.where(img_trimmed != img_ann)
+        self.frames_changed = np.any(comparison)
+        #this action should never change the cell info
+
+        self.annotated[frame,:,:,self.feature] = img_trimmed
 
     def action_handle_draw(self, trace, edit_value, brush_size, erase, frame):
 
-        annotated = self.annotated[frame,:,:,self.feature]
+        annotated = np.copy(self.annotated[frame,:,:,self.feature])
 
         in_original = np.any(np.isin(annotated, edit_value))
 
@@ -227,6 +234,11 @@ class ZStackReview:
         #cell addition
         elif in_modified and not in_original:
             self.add_cell_info(feature = self.feature, add_label = edit_value, frame = frame)
+
+        #check for image change, in case pixels changed but no new or del cell
+        comparison = np.where(annotated != self.annotated[frame,:,:,self.feature])
+        self.frames_changed = np.any(comparison)
+        #if info changed, self.info_changed set to true with info helper functions
 
         self.annotated[frame,:,:,self.feature] = annotated
 
@@ -260,6 +272,9 @@ class ZStackReview:
         img_ann = self.annotated[frame,:,:,self.feature]
         filled_img_ann = flood_fill(img_ann, hole_fill_seed, label, connectivity = 1)
         self.annotated[frame,:,:,self.feature] = filled_img_ann
+
+        #never changes info but always changes annotation
+        self.frames_changed = True
 
     def action_new_cell_stack(self, label, frame):
 
@@ -304,6 +319,8 @@ class ZStackReview:
 
         self.annotated[frame,:,:,self.feature] = ann_img
 
+        self.frames_changed = self.info_changed = True
+
     def action_swap_all_frame(self, label_1, label_2, frame_1, frame_2):
 
         for frame in range(self.annotated.shape[0]):
@@ -319,6 +336,8 @@ class ZStackReview:
         self.cell_info[self.feature][label_1].update({'frames': cell_info_2['frames']})
         self.cell_info[self.feature][label_2].update({'frames': cell_info_1['frames']})
 
+        self.frames_changed = self.info_changed = True
+
     def action_predict_single(self, frame):
 
         '''
@@ -333,11 +352,15 @@ class ZStackReview:
             img = self.annotated[prev_slice,:,:,self.feature]
             next_img = self.annotated[current_slice,:,:,self.feature]
             updated_slice = predict_zstack_cell_ids(img, next_img)
-            self.annotated[current_slice,:,:,int(self.feature)] = updated_slice
 
+            #check if image changed
+            comparison = np.where(next_img != updated_slice)
+            self.frames_changed = np.any(comparison)
 
-        #update cell_info
-            self.create_cell_info(feature = int(self.feature))
+            #if the image changed, update self.annotated and remake cell info
+            if self.frames_changed:
+                self.annotated[current_slice,:,:,int(self.feature)] = updated_slice
+                self.create_cell_info(feature = int(self.feature))
 
     def action_predict_zstack(self):
         '''
@@ -355,6 +378,7 @@ class ZStackReview:
             self.annotated[zslice + 1,:,:,self.feature] = predicted_next
 
         #remake cell_info dict based on new annotations
+        self.frames_changed = True
         self.create_cell_info(feature = self.feature)
 
     def action_replace(self, label_1, label_2, frame_1, frame_2):
@@ -470,6 +494,8 @@ class ZStackReview:
 
             self.num_cells[feature] += 1
 
+        #if adding cell, frames and info have necessarily changed
+        self.frames_changed = self.info_changed = True
 
     def del_cell_info(self, feature, del_label, frame):
         '''
@@ -488,6 +514,8 @@ class ZStackReview:
             ids = self.cell_ids[feature]
             self.cell_ids[feature] = np.delete(ids, np.where(ids == np.int64(del_label)))
 
+        #if deleting cell, frames and info have necessarily changed
+        self.frames_changed = self.info_changed = True
 
     def create_cell_info(self, feature):
         '''
@@ -513,6 +541,8 @@ class ZStackReview:
                 if cell in annotated[frame,:,:]:
                     self.cell_info[feature][cell]['frames'].append(int(frame))
             self.cell_info[feature][cell]['slices'] = ''
+
+        self.info_changed = True
 
     def create_lineage(self):
         for cell in self.cell_ids[self.feature]:
@@ -558,6 +588,8 @@ class TrackReview:
 
         self.current_frame = 0
 
+        self.frames_changed = False
+        self.info_changed = False
 
     @property
     def readable_tracks(self):
@@ -668,6 +700,10 @@ class TrackReview:
         img_ann = self.tracked[frame,:,:,0]
         contig_cell = flood(image = img_ann, seed_point = (int(y_location/self.scale_factor), int(x_location/self.scale_factor)))
         img_trimmed = np.where(np.logical_and(np.invert(contig_cell), img_ann == label), 0, img_ann)
+
+        comparison = np.where(img_trimmed != img_ann)
+        self.frames_changed = np.any(comparison)
+
         self.tracked[frame,:,:,0] = img_trimmed
 
     def action_fill_hole(self, label, frame, x_location, y_location):
@@ -685,9 +721,11 @@ class TrackReview:
         filled_img_ann = flood_fill(img_ann, hole_fill_seed, label, connectivity = 1)
         self.tracked[frame,:,:,0] = filled_img_ann
 
+        self.frames_changed = True
+
     def action_handle_draw(self, trace, edit_value, brush_size, erase, frame):
 
-        annotated = self.tracked[frame]
+        annotated = np.copy(self.tracked[frame])
 
         in_original = np.any(np.isin(annotated, edit_value))
 
@@ -716,6 +754,9 @@ class TrackReview:
         # cell addition
         elif in_modified and not in_original:
             self.add_cell_info(add_label = edit_value, frame = frame)
+
+        comparison = np.where(annotated != self.tracked[frame])
+        self.frames_changed = np.any(comparison)
 
         self.tracked[frame] = annotated
 
@@ -818,6 +859,8 @@ class TrackReview:
 
         self.tracked[frame,:,:,0] = ann_img
 
+        self.frames_changed = True
+
     def action_swap_tracks(self, label_1, label_2, frame_1, frame_2):
         def relabel(old_label, new_label):
             for frame in self.tracked:
@@ -840,6 +883,8 @@ class TrackReview:
         relabel(label_2, label_1)
         relabel(-1, label_2)
 
+        self.frames_changed = self.info_changed = True
+
     def action_set_parent(self, label_1, label_2, frame_1, frame_2):
         """
         label_1 gave birth to label_2
@@ -852,6 +897,8 @@ class TrackReview:
         track_1["daughters"].append(label_2)
         track_2["parent"] = label_1
         track_1["frame_div"] = frame_div
+
+        self.info_changed = True
 
     def action_replace(self, label_1, label_2, frame_1, frame_2):
         """
@@ -882,6 +929,8 @@ class TrackReview:
                 track["daughters"].remove(label_2)
             except ValueError:
                 pass
+
+        self.frames_changed = self.info_changed = True
 
     def action_delete(self, label, frame):
         """
@@ -934,6 +983,8 @@ class TrackReview:
             track_old["frame_div"] = None
             track_old["capped"] = True
 
+            self.frames_changed = self.info_changed = True
+
     def action_new_single_cell(self, label, frame):
         """
         Create new label in just one frame
@@ -969,6 +1020,8 @@ class TrackReview:
             self.tracks[add_label].update({'parent': None})
             self.tracks[add_label].update({'capped': False})
 
+        self.frames_changed = self.info_changed = True
+
     def del_cell_info(self, del_label, frame):
         '''
         helper function for actions that remove a cell from the trk
@@ -990,6 +1043,8 @@ class TrackReview:
                     pass
                 if track["parent"] == del_label:
                     track["parent"] = None
+
+        self.frames_changed = self.info_changed = True
 
 
 def consecutive(data, stepsize=1):

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -346,8 +346,8 @@ var dimensions = undefined;
 var tracks = undefined;
 var maxTrack;
 var mode = new Mode(Modes.none, {});
-var raw_image = undefined;
-var seg_image = undefined;
+var raw_image = new Image();
+var seg_image = new Image();
 var seg_array;
 var scale;
 var mouse_x = 0;
@@ -564,21 +564,15 @@ function fetch_and_render_frame() {
     type: 'GET',
     url: "frame/" + current_frame + "/" + project_id,
     success: function(payload) {
-      if (seg_image === undefined) {
-        seg_image = new Image();
-      }
-      if (raw_image === undefined) {
-        raw_image = new Image();
-      }
-
+      // load new value of seg_array
+      // array of arrays, contains annotation data for frame
       seg_array = payload.seg_arr;
-
       seg_image.src = payload.segmented;
       seg_image.onload = render_frame;
       raw_image.src = payload.raw;
       raw_image.onload = render_frame;
     },
-    async: true
+    async: false
   });
 }
 

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -740,33 +740,28 @@ function prepare_canvas() {
   }, false);
 }
 
-function reload_tracks() {
-  $.ajax({
-    type:'GET',
-    url:"tracks/" + project_id,
-    data: project_id,
-    success: function (payload) {
-      tracks = payload.tracks;
-      maxTrack = Math.max(... Object.keys(tracks).map(Number));
-    },
-    async: false
-  });
-}
-
-function action(action, info) {
+function action(action, info, frame = current_frame) {
   $.ajax({
     type:'POST',
-    url:"action/" + project_id + "/" + action,
+    url:"action/" + project_id + "/" + action + "/" + frame,
     data: info,
     success: function (payload) {
       if (payload.error) {
         alert(payload.error);
       }
-      if (payload.frames_changed) {
-        fetch_and_render_frame();
+      if (payload.imgs) {
+        // load new value of seg_array
+        // array of arrays, contains annotation data for frame
+        seg_array = payload.imgs.seg_arr;
+        seg_image.src = payload.imgs.segmented;
+        raw_image.src = payload.imgs.raw;
       }
-      if (payload.tracks_changed) {
-        reload_tracks();
+      if (payload.tracks) {
+        tracks = payload.tracks;
+        maxTrack = Math.max(... Object.keys(tracks).map(Number));
+      }
+      if (payload.tracks || payload.imgs) {
+        render_frame();
       }
     },
     async: false

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -599,13 +599,6 @@ function load_file(file) {
   });
 }
 
-async function fetch_frame(frame) {
-  return $.ajax({
-    type: 'GET',
-    url: "frame/" + frame+ "/" + project_id,
-  });
-}
-
 function prepare_canvas() {
   $('#canvas').click(function(evt) {
     if (!edit_mode) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -729,14 +729,6 @@ function load_file(file) {
   });
 }
 
-async function fetch_frame(frame) {
-  return $.ajax({
-    type: 'GET',
-    url: "frame/" + frame + "/" + project_id
-
-  });
-}
-
 function prepare_canvas() {
   $('#canvas').click(function(evt) {
     // bind click events on canvas

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -890,37 +890,35 @@ function prepare_canvas() {
   }, false);
 }
 
-function reload_tracks() {
-  $.ajax({
-    type:'GET',
-    url:"tracks/" + project_id,
-    data: project_id,
-    success: function (payload) {
-      tracks = payload.tracks;
-      //update maxLabelsMap when we get new track info
-      for (let i = 0; i < Object.keys(tracks).length; i++){
-        let key = Object.keys(tracks)[i]; //the keys are strings
-        maxLabelsMap.set(i, Math.max(... Object.keys(tracks[key]).map(Number)));
-      };
-    },
-    async: false
-  });
-}
-
-function action(action, info) {
+function action(action, info, frame = current_frame) {
   $.ajax({
     type:'POST',
-    url:"action/" + project_id + "/" + action,
+    url:"action/" + project_id + "/" + action + "/" + frame,
     data: info,
     success: function (payload) {
       if (payload.error) {
         alert(payload.error);
       }
-      if (payload.frames_changed) {
-        fetch_and_render_frame();
+      if (payload.imgs) {
+        // load new value of seg_array
+        // array of arrays, contains annotation data for frame
+        seg_array = payload.imgs.seg_arr;
+
+        seg_image.src = payload.imgs.segmented;
+        // seg_image.onload = render_frame;
+        raw_image.src = payload.imgs.raw;
+        // raw_image.onload = render_frame;
       }
-      if (payload.tracks_changed) {
-        reload_tracks();
+      if (payload.tracks) {
+        tracks = payload.tracks;
+      //update maxLabelsMap when we get new track info
+        for (let i = 0; i < Object.keys(tracks).length; i++){
+          let key = Object.keys(tracks)[i]; //the keys are strings
+          maxLabelsMap.set(i, Math.max(... Object.keys(tracks[key]).map(Number)));
+        }
+      }
+      if (payload.tracks || payload.imgs) {
+        render_frame();
       }
     },
     async: false

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -453,8 +453,8 @@ var dimensions = undefined;
 var tracks = undefined;
 let maxLabelsMap = new Map();
 var mode = new Mode(Modes.none, {});
-var raw_image = undefined;
-var seg_image = undefined;
+var raw_image = new Image();
+var seg_image = new Image();
 var seg_array; // declare here so it is global var
 var scale;
 var mouse_x = 0;
@@ -685,23 +685,15 @@ function fetch_and_render_frame() {
     type: 'GET',
     url: "frame/" + current_frame + "/" + project_id,
     success: function(payload) {
-      if (seg_image === undefined) {
-        seg_image = new Image();
-      }
-      if (raw_image === undefined) {
-        raw_image = new Image();
-      }
-
       // load new value of seg_array
-      // array of arrays, contains annotation raw data for frame
+      // array of arrays, contains annotation data for frame
       seg_array = payload.seg_arr;
-
       seg_image.src = payload.segmented;
       seg_image.onload = render_frame;
       raw_image.src = payload.raw;
       raw_image.onload = render_frame;
     },
-    async: true
+    async: false
   });
 }
 


### PR DESCRIPTION
browser/caliban.py keeps track of whether actions change the annotations or info, which application.py uses to send the appropriate payload (if frames change, send the updated frame, if info changes, send the updated info) in response to the action.

Also cleans up related code (removes unnecessary ajax/flask functions, cleans up TrackReview and ZStackReview attributes, use np.where for all pixel-editing actions).