### PR TITLE
Refactor (browser)

### DIFF
--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -853,6 +853,9 @@ class TrackReview:
 
         if last_frame_parent < first_frame_daughter:
             track_1["daughters"].append(label_2)
+            daughters = np.unique(track_1["daughters"]).tolist()
+            track_1["daughters"] = daughters
+
             track_2["parent"] = label_1
 
             if track_1["frame_div"] is None:

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -254,9 +254,11 @@ class ZStackReview:
 
     def action_change_feature(self, feature):
         self.feature = feature
+        self.frames_changed = True
 
     def action_change_channel(self, channel):
         self.channel = channel
+        self.frames_changed = True
 
     def action_fill_hole(self, label, frame, x_location, y_location):
         '''

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -217,22 +217,22 @@ class Mode {
   // keybinds that apply in bulk mode, answering question/prompt
   handle_mode_question_keybind(key) {
     if (key === " ") {
-      if (this.action == "new_track") {
+      if (this.action === "new_track") {
         action("create_all_new", this.info);
         this.clear();
-      } else if (this.action == "set_parent") {
+      } else if (this.action === "set_parent") {
         action(this.action, this.info);
         this.clear();
-      } else if (this.action == "replace") {
+      } else if (this.action === "replace") {
         action(this.action, this.info);
         this.clear();
-      } else if (this.action == "watershed") {
+      } else if (this.action === "watershed") {
         action(this.action, this.info);
         this.clear();
-      } else if (this.action == "delete_cell") {
+      } else if (this.action === "delete_cell") {
         action(this.action, this.info);
         this.clear();
-      } else if (this.action == "swap_cells") {
+      } else if (this.action === "swap_cells") {
         action("swap_tracks", this.info);
         this.clear();
       } else if (this.action === "flood_cell") {

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -25,14 +25,14 @@ class Mode {
   // these keybinds apply regardless of
   // edit_mode, mode.action, or mode.kind
   handle_universal_keybind(key) {
-    if (key === 'a') {
+    if (key === 'a' || key === 'ArrowLeft') {
       // go backward one frame
       current_frame -= 1;
       if (current_frame < 0) {
         current_frame = max_frames - 1;
       }
       fetch_and_render_frame();
-    } else if (key === 'd') {
+    } else if (key === 'd' || key === 'ArrowRight') {
       // go forward one frame
       current_frame += 1;
       if (current_frame >= max_frames) {

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -61,10 +61,8 @@ class Mode {
       edit_mode = !edit_mode;
       render_frame();
     } if (key === "=") {
-      // increase edit_value, no upper limit
-      // TODO: this probably should have an upper limit,
-      // no reason for this to be unlimited
-      edit_value += 1;
+      // increase edit_value up to max label + 1 (guaranteed unused)
+      edit_value = Math.min(edit_value + 1, maxTrack + 1);
       render_log();
     } else if (key === "-") {
       // decrease edit_value, minimum 1

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -19,7 +19,7 @@ class Mode {
     }
     this.action = "";
     this.prompt = "";
-    render_log();
+    render_info_display();
   }
 
   // these keybinds apply regardless of
@@ -62,15 +62,15 @@ class Mode {
     } else if (key === "=") {
       // increase edit_value up to max label + 1 (guaranteed unused)
       edit_value = Math.min(edit_value + 1, maxTrack + 1);
-      render_log();
+      render_info_display();
     } else if (key === "-") {
       // decrease edit_value, minimum 1
       edit_value = Math.max(edit_value - 1, 1);
-      render_log();
+      render_info_display();
     } else if (key === "x") {
       // turn eraser on and off
       erase = !erase;
-      render_log();
+      render_info_display();
     } else if (key === "ArrowDown") {
       // decrease brush size, minimum size 1
       brush_size = Math.max(brush_size - 1, 1);
@@ -99,7 +99,7 @@ class Mode {
     } else if (key === 'n') {
       // set edit value to something unused
       edit_value = maxTrack + 1;
-      render_log();
+      render_info_display();
       // when value of brush determines color of brush, render_frame instead
     } else if (key === 'i') {
       // toggle light/dark inversion of raw img
@@ -142,19 +142,19 @@ class Mode {
       this.kind = Modes.question;
       this.action = "fill_hole";
       this.prompt = "Select hole to fill in cell " + this.info['label'];
-      render_log();
+      render_info_display();
     } else if (key === "c") {
       // create new
       this.kind = Modes.question;
       this.action = "new_track";
       this.prompt = "CREATE NEW (SPACE=ALL SUBSEQUENT FRAMES / S=ONLY THIS FRAME / ESC=CANCEL)";
-      render_log();
+      render_info_display();
     } else if (key === "x") {
       // delete label from frame
       this.kind = Modes.question;
       this.action = "delete_cell";
       this.prompt = "delete label " + this.info.label + " in frame " + this.info.frame + "? " + answer;
-      render_log();
+      render_info_display();
     } else if (key === "-") {
       // cycle highlight to prev label
       if (this.highlighted_cell_one === 1) {
@@ -189,25 +189,25 @@ class Mode {
       this.kind = Modes.question;
       this.action = "set_parent";
       this.prompt = "Set " + this.info.label_1 + " as parent of " + this.info.label_2 + "? " + answer;
-      render_log();
+      render_info_display();
     } else if (key === "r") {
       // replace
       this.kind = Modes.question;
       this.action = "replace";
       this.prompt = "Replace " + this.info.label_2 + " with " + this.info.label_1 + "? " + answer;
-      render_log();
+      render_info_display();
     } else if (key === "s") {
       // swap
       this.kind = Modes.question;
       this.action = "swap_cells";
       this.prompt = "SPACE = SWAP IN ALL FRAMES / S = SWAP IN ONLY ONE FRAME / ESC = CANCEL SWAP";
-      render_log();
+      render_info_display();
     } else if (key === "w") {
       // watershed
       this.kind = Modes.question;
       this.action = "watershed";
       this.prompt = "Perform watershed to split " + this.info.label_1 + "? " + answer;
-      render_log();
+      render_info_display();
     }
   }
 
@@ -594,7 +594,8 @@ function render_cell_info() {
   }
 }
 
-function render_log() {
+// updates html display of side info panel
+function render_info_display() {
   // always show current frame
   $('#frame').html(current_frame);
 
@@ -671,7 +672,7 @@ function render_frame() {
     // draw annotations
     render_annotations(ctx);
   }
-  render_log();
+  render_info_display();
 }
 
 function fetch_and_render_frame() {
@@ -743,7 +744,7 @@ function handle_mousemove(evt) {
   // update displayed info depending on where mouse is
   mouse_x = evt.offsetX;
   mouse_y = evt.offsetY;
-  render_log();
+  render_info_display();
 
   // update brush preview
   if (edit_mode) {
@@ -784,7 +785,7 @@ function prepare_canvas() {
     if (!edit_mode) {
       mode.click(evt);
     }
-    render_log();
+    render_info_display();
   });
   // bind scroll wheel
   $('#canvas').on('wheel', function(evt) {

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -69,10 +69,10 @@ class Mode {
       edit_value = Math.max(edit_value - 1, 1);
       render_log();
     } else if (key === "x") {
-      //turn eraser on and off
+      // turn eraser on and off
       erase = !erase;
       render_log();
-    } else if (key === ",") {
+    } else if (key === "ArrowDown") {
       // decrease brush size, minimum size 1
       brush_size = Math.max(brush_size - 1, 1);
 
@@ -84,19 +84,19 @@ class Mode {
 
       // redraw the frame with the updated brush preview
       render_frame();
-    } else if (key === ".") {
+    } else if (key === "ArrowUp") {
       // increase brush size
       // shouldn't be larger than the image
       brush_size = Math.min(self.brush_size + 1,
           dimensions[0]/scale, dimensions[1]/scale);
 
-      //update brush with its new size
+      // update brush with its new size
       let hidden_ctx = $('#hidden_canvas').get(0).getContext("2d");
       hidden_ctx.clearRect(0,0,dimensions[0],dimensions[1]);
       brush.radius = brush_size * scale;
       brush.draw(hidden_ctx);
 
-      //redraw the frame with the updated brush preview
+      // redraw the frame with the updated brush preview
       render_frame();
     } else if (key === 'n') {
       // set edit value to something unused

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -15,7 +15,7 @@ class Mode {
     this.highlighted_cell_two = -1;
     //reset highlighting in image if this is being shown
     if (current_highlight) {
-      render_frame();
+      render_image_display();
     }
     this.action = "";
     this.prompt = "";
@@ -45,11 +45,11 @@ class Mode {
     } else if (key === 'h') {
       // toggle highlight
       current_highlight = !current_highlight;
-      render_frame();
+      render_image_display();
     } else if (key === 'z') {
       // toggle rendering_raw
       rendering_raw = !rendering_raw;
-      render_frame();
+      render_image_display();
     }
   }
 
@@ -58,7 +58,7 @@ class Mode {
     if (key === "e") {
       // toggle edit mode
       edit_mode = !edit_mode;
-      render_frame();
+      render_image_display();
     } else if (key === "=") {
       // increase edit_value up to max label + 1 (guaranteed unused)
       edit_value = Math.min(edit_value + 1, maxTrack + 1);
@@ -82,7 +82,7 @@ class Mode {
       brush.draw(hidden_ctx);
 
       // redraw the frame with the updated brush preview
-      render_frame();
+      render_image_display();
     } else if (key === "ArrowUp") {
       // increase brush size, shouldn't be larger than the image
       brush_size = Math.min(self.brush_size + 1,
@@ -95,16 +95,16 @@ class Mode {
       brush.draw(hidden_ctx);
 
       // redraw the frame with the updated brush preview
-      render_frame();
+      render_image_display();
     } else if (key === 'n') {
       // set edit value to something unused
       edit_value = maxTrack + 1;
       render_info_display();
-      // when value of brush determines color of brush, render_frame instead
+      // when value of brush determines color of brush, render_image instead
     } else if (key === 'i') {
       // toggle light/dark inversion of raw img
       display_invert = !display_invert;
-      render_frame();
+      render_image_display();
     }
   }
 
@@ -113,7 +113,7 @@ class Mode {
     if (key === "e") {
       // toggle edit mode
       edit_mode = !edit_mode;
-      render_frame();
+      render_image_display();
     } else if (key === "-" && this.highlighted_cell_one !== -1) {
       // cycle highlight to prev label
       if (this.highlighted_cell_one === 1) {
@@ -121,7 +121,7 @@ class Mode {
       } else {
         this.highlighted_cell_one -= 1;
       }
-      render_frame();
+      render_image_display();
     } else if (key === "=" && this.highlighted_cell_one !== -1) {
       // cycle highlight to next label
       if (this.highlighted_cell_one === maxTrack) {
@@ -129,7 +129,7 @@ class Mode {
       } else {
         this.highlighted_cell_one += 1;
       }
-      render_frame();
+      render_image_display();
     }
   }
 
@@ -166,7 +166,7 @@ class Mode {
       let temp_highlight = this.highlighted_cell_one;
       this.clear();
       this.highlighted_cell_one = temp_highlight;
-      render_frame();
+      render_image_display();
     } else if (key === "=") {
       // cycle highlight to next label
       if (this.highlighted_cell_one === maxTrack) {
@@ -178,7 +178,7 @@ class Mode {
       let temp_highlight = this.highlighted_cell_one;
       this.clear();
       this.highlighted_cell_one = temp_highlight;
-      render_frame();
+      render_image_display();
     }
   }
 
@@ -390,7 +390,7 @@ class Mode {
     } else if (this.kind  === Modes.multiple) {
       this.handle_mode_multiple_click(evt);
     }
-    render_frame();
+    render_image_display();
   }
 
   render() {
@@ -609,7 +609,7 @@ function render_info_display() {
   $('#mode').html(mode.render());
 }
 
-function render_edit(ctx) {
+function render_edit_image(ctx) {
   let hidden_canvas = document.getElementById('hidden_canvas');
 
   ctx.clearRect(0, 0, dimensions[0], dimensions[1]);
@@ -636,7 +636,7 @@ function render_edit(ctx) {
   ctx.restore();
 }
 
-function render_raw(ctx) {
+function render_raw_image(ctx) {
   ctx.clearRect(0, 0, dimensions[0], dimensions[1]);
   ctx.drawImage(raw_image, 0, 0, dimensions[0], dimensions[1]);
 
@@ -647,7 +647,7 @@ function render_raw(ctx) {
   ctx.putImageData(image_data, 0, 0);
 }
 
-function render_annotations(ctx) {
+function render_annotation_image(ctx) {
   ctx.clearRect(0, 0, dimensions[0], dimensions[1]);
   ctx.drawImage(seg_image, 0, 0, dimensions[0], dimensions[1]);
   if (current_highlight) {
@@ -658,19 +658,19 @@ function render_annotations(ctx) {
   }
 }
 
-function render_frame() {
+function render_image_display() {
   let ctx = $('#canvas').get(0).getContext("2d");
   ctx.imageSmoothingEnabled = false;
 
   if (edit_mode) {
     // edit mode (annotations overlaid on raw + brush preview)
-    render_edit(ctx);
+    render_edit_image(ctx);
   } else if (rendering_raw) {
     // draw raw image
-    render_raw(ctx);
+    render_raw_image(ctx);
   } else {
     // draw annotations
-    render_annotations(ctx);
+    render_annotation_image(ctx);
   }
   render_info_display();
 }
@@ -684,9 +684,9 @@ function fetch_and_render_frame() {
       // array of arrays, contains annotation data for frame
       seg_array = payload.seg_arr;
       seg_image.src = payload.segmented;
-      seg_image.onload = render_frame;
+      seg_image.onload = render_image_display;
       raw_image.src = payload.raw;
-      raw_image.onload = render_frame;
+      raw_image.onload = render_image_display;
     },
     async: false
   });
@@ -721,7 +721,7 @@ function handle_scroll(evt) {
   if (rendering_raw || edit_mode) {
     let delta = - evt.originalEvent.deltaY / 2;
     current_contrast = Math.max(current_contrast + delta, -100);
-    render_frame();
+    render_image_display();
   }
 }
 
@@ -762,7 +762,7 @@ function handle_mousemove(evt) {
     brush.x = mouse_x;
     brush.y = mouse_y;
     brush.draw(hidden_ctx);
-    render_frame();
+    render_image_display();
   }
 }
 
@@ -832,7 +832,7 @@ function action(action, info, frame = current_frame) {
         maxTrack = Math.max(... Object.keys(tracks).map(Number));
       }
       if (payload.tracks || payload.imgs) {
-        render_frame();
+        render_image_display();
       }
     },
     async: false

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -217,37 +217,57 @@ class Mode {
     if (key === " ") {
       if (this.action === "flood_cell") {
         action("flood_cell", this.info);
-        this.clear();
       } else if (this.action === "trim_pixels") {
         action("trim_pixels", this.info);
-        this.clear();
       } if (this.action === "new_track") {
         action("create_all_new", this.info);
-        this.clear();
       } else if (this.action === "delete_cell") {
         action(this.action, this.info);
-        this.clear();
       } else if (this.action === "set_parent") {
-        action(this.action, this.info);
-        this.clear();
+        if (this.info.label_1 !== this.info.label_2 &&
+          this.info.frame_1 < this.info.frame_2) {
+          let send_info = {"label_1": this.info.label_1,
+                           "label_2": this.info.label_2};
+          action(this.action, send_info);
+        }
       } else if (this.action === "replace") {
-        action(this.action, this.info);
-        this.clear();
+        if (this.info.label_1 !== this.info.label_2) {
+          let send_info = {"label_1": this.info.label_1,
+                           "label_2": this.info.label_2};
+          action(this.action, send_info);
+        }
       } else if (this.action === "swap_cells") {
-        action("swap_tracks", this.info);
-        this.clear();
+        if (this.info.label_1 !== this.info.label_2) {
+          let send_info = {"label_1": this.info.label_1,
+                           "label_2": this.info.label_2}
+          action("swap_tracks", send_info);
+        }
       } else if (this.action === "watershed") {
-        action(this.action, this.info);
-        this.clear();
+        if (this.info.frame_1 === this.info.frame_2 &&
+          this.info.label_1 === this.info.label_2) {
+          this.info.frame = this.info.frame_1;
+          this.info.label = this.info.label_1;
+          delete this.info.frame_1;
+          delete this.info.frame_2;
+          delete this.info.label_1;
+          delete this.info.label_2;
+          action(this.action, this.info);
+        }
       }
+      this.clear();
     } else if (key === "s") {
       if (this.action === "new_track") {
         action("create_single_new", this.info);
-        this.clear();
       } else if (this.action === "swap_cells") {
-        action("swap_single_frame", this.info);
-        this.clear();
+        if (this.info.label_1 !== this.info.label_2 &&
+          this.info.frame_1 === this.info.frame_2) {
+          let send_info = {"label_1": this.info.label_1,
+                           "label_2": this.info.label_2,
+                           "frame": this.info.frame_1};
+          action("swap_single_frame", send_info);
+        }
       }
+      this.clear();
     }
   }
 
@@ -329,40 +349,28 @@ class Mode {
     this.highlighted_cell_one = this.info.label;
     this.highlighted_cell_two = current_label;
 
-    if (this.info.label === current_label) {
-      this.info = {"label_1": this.info.label,
-                  "label_2": current_label,
-                  "frame": current_frame,
-                  "x1_location": temp_x,
-                  "y1_location": temp_y,
-                  "x2_location": mouse_x,
-                  "y2_location": mouse_y};
-    } else {
-      this.info = {"label_1": this.info.label,
-                  "frame_1": this.info.frame,
-                  "label_2": current_label,
-                  "frame_2": current_frame};
-    }
+    this.info = {"label_1": this.info.label,
+                "label_2": current_label,
+                "frame_1": this.info.frame,
+                "frame_2": current_frame,
+                "x1_location": temp_x,
+                "y1_location": temp_y,
+                "x2_location": mouse_x,
+                "y2_location": mouse_y};
   }
 
   handle_mode_multiple_click(evt) {
     this.highlighted_cell_one = this.info.label_1;
     this.highlighted_cell_two = current_label;
 
-    if (this.info.label_1 === current_label) {
-      this.info = {"label_1": this.info.label_1,
-                  "label_2": current_label,
-                  "frame": current_frame,
-                  "x1_location": temp_x,
-                  "y1_location": temp_y,
-                  "x2_location": mouse_x,
-                  "y2_location": mouse_y};
-    } else {
-      this.info = {"label_1": this.info.label_1,
-                  "frame_1": this.info.frame_1,
-                  "label_2": current_label,
-                  "frame_2": current_frame};
-    }
+    this.info = {"label_1": this.info.label_1,
+                "label_2": current_label,
+                "frame_1": this.info.frame_1,
+                "frame_2": current_frame,
+                "x1_location": temp_x,
+                "y1_location": temp_y,
+                "x2_location": mouse_x,
+                "y2_location": mouse_y};
   }
 
   click(evt) {

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -54,13 +54,12 @@ class Mode {
   }
 
   // keybinds that apply when in edit mode
-  // TODO: change brush-size keybinds to up/down
   handle_edit_keybind(key) {
     if (key === "e") {
       // toggle edit mode
       edit_mode = !edit_mode;
       render_frame();
-    } if (key === "=") {
+    } else if (key === "=") {
       // increase edit_value up to max label + 1 (guaranteed unused)
       edit_value = Math.min(edit_value + 1, maxTrack + 1);
       render_log();
@@ -85,8 +84,7 @@ class Mode {
       // redraw the frame with the updated brush preview
       render_frame();
     } else if (key === "ArrowUp") {
-      // increase brush size
-      // shouldn't be larger than the image
+      // increase brush size, shouldn't be larger than the image
       brush_size = Math.min(self.brush_size + 1,
           dimensions[0]/scale, dimensions[1]/scale);
 
@@ -102,7 +100,7 @@ class Mode {
       // set edit value to something unused
       edit_value = maxTrack + 1;
       render_log();
-      // when value of brush determines color of brush preview, render_frame instead
+      // when value of brush determines color of brush, render_frame instead
     } else if (key === 'i') {
       // toggle light/dark inversion of raw img
       display_invert = !display_invert;
@@ -113,6 +111,7 @@ class Mode {
   // keybinds that apply in bulk mode, nothing selected
   handle_mode_none_keybind(key) {
     if (key === "e") {
+      // toggle edit mode
       edit_mode = !edit_mode;
       render_frame();
     } else if (key === "-" && this.highlighted_cell_one !== -1) {
@@ -274,7 +273,8 @@ class Mode {
   // handle all keypresses
   handle_key(key) {
     // universal keybinds always apply
-    // keys a, d, ESC, h are reserved for universal keybinds
+    // keys a, d, left arrow, right arrow, ESC, h
+    // are reserved for universal keybinds
     this.handle_universal_keybind(key);
     if (edit_mode) {
       this.handle_edit_keybind(key);

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -513,9 +513,15 @@ function invert(img) {
 }
 
 function label_under_mouse() {
-  let img_y = Math.floor(mouse_y/scale)
-  let img_x = Math.floor(mouse_x/scale)
-  let new_label = seg_array[img_y][img_x]; //check array value at mouse location
+  let img_y = Math.floor(mouse_y/scale);
+  let img_x = Math.floor(mouse_x/scale);
+  let new_label;
+  if (img_y >= 0 && img_y < seg_array.length &&
+      img_x >= 0 && img_x < seg_array[0].length) {
+    new_label = seg_array[img_y][img_x]; //check array value at mouse location
+  } else {
+    new_label = 0;
+  }
   return new_label;
 }
 

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -531,16 +531,7 @@ function label_under_mouse() {
   return new_label;
 }
 
-function render_log() {
-  current_label = label_under_mouse();
-
-  $('#frame').html(current_frame);
-  if (current_label !== 0) {
-    $('#label').html(current_label);
-  } else {
-    $('#label').html("");
-  }
-
+function render_highlight_info() {
   if (current_highlight) {
     $('#highlight').html("ON");
     if (mode.highlighted_cell_one !== -1) {
@@ -556,7 +547,9 @@ function render_log() {
     $('#highlight').html("OFF");
     $('#currently_highlighted').html("none");
   }
+}
 
+function render_edit_info() {
   if (edit_mode) {
     $('#edit_mode').html("ON");
     $('#edit_brush_row').css('visibility', 'visible');
@@ -578,8 +571,12 @@ function render_log() {
     $('#edit_label_row').css('visibility', 'hidden');
     $('#edit_erase_row').css('visibility', 'hidden');
   }
+}
 
+function render_cell_info() {
+  current_label = label_under_mouse();
   if (current_label !== 0) {
+    $('#label').html(current_label);
     let track = tracks[current_label.toString()];
     $('#parent').text(track.parent || "None");
     $('#daughters').text("[" + track.daughters.toString() + "]");
@@ -588,11 +585,26 @@ function render_log() {
     $('#capped').text(capped[0].toUpperCase() + capped.substring(1));
     $('#frames').text(track.frames.toString());
   } else {
+    $('#label').html("");
     $('#capped').text("");
+    $('#parent').text("");
     $('#daughters').text("");
     $('#frame_div').text("");
     $('#frames').text("");
   }
+}
+
+function render_log() {
+  // always show current frame
+  $('#frame').html(current_frame);
+
+  render_highlight_info();
+
+  render_edit_info();
+
+  render_cell_info();
+
+  // always show 'state'
   $('#mode').html(mode.render());
 }
 

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -696,9 +696,8 @@ function load_file(file) {
 
 // adjust current_contrast upon mouse scroll
 function handle_scroll(evt) {
-  // only adjust when rendering_raw
-  // (adjustment is only applied to raw)
-  if (rendering_raw) {
+  // adjust contrast whenever we can see raw
+  if (rendering_raw || edit_mode) {
     let delta = - evt.originalEvent.deltaY / 2;
     current_contrast = Math.max(current_contrast + delta, -100);
     render_frame();

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -24,7 +24,7 @@ class Mode {
 
     this.action = "";
     this.prompt = "";
-    render_log();
+    render_info_display();
   }
 
   // these keybinds apply regardless of
@@ -68,15 +68,15 @@ class Mode {
       // increase edit_value up to max label + 1 (guaranteed unused)
       edit_value = Math.min(edit_value + 1,
           maxLabelsMap.get(this.feature) + 1);
-      render_log();
+      render_info_display();
     } else if (key === "-") {
       // decrease edit_value, minimum 1
       edit_value = Math.max(edit_value - 1, 1);
-      render_log();
+      render_info_display();
     } else if (key === "x") {
       // turn eraser on and off
       erase = !erase;
-      render_log();
+      render_info_display();
     } else if (key === "ArrowDown") {
       // decrease brush size, minimum size 1
       brush_size = Math.max(brush_size - 1, 1);
@@ -105,7 +105,7 @@ class Mode {
     } else if (key === 'n') {
       // set edit value to something unused
       edit_value = maxLabelsMap.get(this.feature) + 1;
-      render_log();
+      render_info_display();
       // when value of brush determines color of brush, render_frame instead
     } else if (key === 'i') {
       // toggle light/dark inversion of raw img
@@ -157,7 +157,7 @@ class Mode {
       this.kind = Modes.question;
       this.action = "predict";
       this.prompt = "Predict cell ids for zstack? / S=PREDICT THIS FRAME / SPACE=PREDICT ALL FRAMES / ESC=CANCEL PREDICTION";
-      render_log();
+      render_info_display();
     } else if (key === "-" && this.highlighted_cell_one !== -1) {
       // cycle highlight to prev label
       this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
@@ -180,19 +180,19 @@ class Mode {
       this.kind = Modes.question;
       this.action = "fill_hole";
       this.prompt = "Select hole to fill in cell " + this.info['label'];
-      render_log();
+      render_info_display();
     } else if (key === "c") {
       // create new
       this.kind = Modes.question;
       this.action = "create_new";
       this.prompt = "CREATE NEW(S=SINGLE FRAME / SPACE=ALL SUBSEQUENT FRAMES / ESC=NO)";
-      render_log();
+      render_info_display();
     } else if (key === "x") {
       // delete label from frame
       this.kind = Modes.question;
       this.action = "delete";
       this.prompt = "delete label " + this.info.label + " in frame " + this.info.frame + "? " + answer;
-      render_log();
+      render_info_display();
     } else if (key === "-") {
       // cycle highlight to prev label
       this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
@@ -222,19 +222,19 @@ class Mode {
       this.action = "replace";
       this.prompt = ("Replace " + this.info.label_2 + " with " + this.info.label_1 +
         "? // SPACE = Replace in all frames / S = Replace in this frame only / ESC = Cancel replace");
-      render_log();
+      render_info_display();
     } else if (key === "s") {
       // swap
       this.kind = Modes.question;
       this.action = "swap_cells";
       this.prompt = "SPACE = SWAP IN ALL FRAMES / S = SWAP IN THIS FRAME ONLY / ESC = CANCEL SWAP";
-      render_log();
+      render_info_display();
     } else if (key === "w" ) {
       // watershed
       this.kind = Modes.question;
       this.action = "watershed";
       this.prompt = "Perform watershed to split " + this.info.label_1 + "? " + answer;
-      render_log();
+      render_info_display();
     }
   }
 
@@ -619,7 +619,7 @@ function render_cell_info() {
 }
 
 // updates html display of side info panel
-function render_log() {
+function render_info_display() {
   // always show current frame, feature, channel
   $('#frame').html(current_frame);
   $('#feature').html(mode.feature);
@@ -700,7 +700,7 @@ function render_frame() {
       ctx.putImageData(img_data, 0, 0)
     }
   }
-  render_log();
+  render_info_display();
 }
 
 function fetch_and_render_frame() {
@@ -781,7 +781,7 @@ function handle_mousemove(evt) {
   // update displayed info depending on where mouse is
   mouse_x = evt.offsetX;
   mouse_y = evt.offsetY;
-  render_log();
+  render_info_display();
 
   // update brush preview
   if (edit_mode) {
@@ -822,7 +822,7 @@ function prepare_canvas() {
     if (!edit_mode) {
       mode.click(evt);
     }
-    render_log();
+    render_info_display();
   });
   // bind scroll wheel
   $('#canvas').on('wheel', function(evt) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -18,8 +18,7 @@ class Mode {
     this.highlighted_cell_two = -1;
 
     if (current_highlight) {
-      // update img display
-      render_frame();
+      render_image_display();
     }
 
     this.action = "";
@@ -50,11 +49,11 @@ class Mode {
     } else if (key === 'h') {
       // toggle highlight
       current_highlight = !current_highlight;
-      render_frame();
+      render_image_display();
     } else if (key === 'z') {
       // toggle rendering_raw
       rendering_raw = !rendering_raw;
-      render_frame();
+      render_image_display();
     }
   }
 
@@ -63,7 +62,7 @@ class Mode {
     if (key === "e") {
       // toggle edit mode
       edit_mode = !edit_mode;
-      render_frame();
+      render_image_display();
     } else if (key === "=") {
       // increase edit_value up to max label + 1 (guaranteed unused)
       edit_value = Math.min(edit_value + 1,
@@ -88,7 +87,7 @@ class Mode {
       brush.draw(hidden_ctx);
 
       // redraw the frame with the updated brush preview
-      render_frame();
+      render_image_display();
     } else if (key === "ArrowUp") {
       //increase brush size, shouldn't be larger than the image
       brush_size = Math.min(self.brush_size + 1,
@@ -101,16 +100,16 @@ class Mode {
       brush.draw(hidden_ctx);
 
       // redraw the frame with the updated brush preview
-      render_frame();
+      render_image_display();
     } else if (key === 'n') {
       // set edit value to something unused
       edit_value = maxLabelsMap.get(this.feature) + 1;
       render_info_display();
-      // when value of brush determines color of brush, render_frame instead
+      // when value of brush determines color of brush, render_image instead
     } else if (key === 'i') {
       // toggle light/dark inversion of raw img
       display_invert = !display_invert;
-      render_frame();
+      render_image_display();
     }
   }
 
@@ -119,7 +118,7 @@ class Mode {
     if (key === "e") {
       // toggle edit mode
       edit_mode = !edit_mode;
-      render_frame();
+      render_image_display();
     } else if (key === "f") {
       // cycle forward one feature, if applicable
       if (feature_max > 0) {
@@ -162,12 +161,12 @@ class Mode {
       // cycle highlight to prev label
       this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
           1, maxLabelsMap.get(this.feature));
-      render_frame();
+      render_image_display();
     } else if (key === "=" && this.highlighted_cell_one !== -1) {
       // cycle highlight to next label
       this.highlighted_cell_one = this.increment_value(this.highlighted_cell_one,
           1, maxLabelsMap.get(this.feature));
-      render_frame();
+      render_image_display();
     }
   }
 
@@ -201,7 +200,7 @@ class Mode {
       let temp_highlight = this.highlighted_cell_one;
       this.clear();
       this.highlighted_cell_one = temp_highlight;
-      render_frame();
+      render_image_display();
     } else if (key === "=") {
       // cycle highlight to next label
       this.highlighted_cell_one = this.increment_value(this.highlighted_cell_one,
@@ -210,7 +209,7 @@ class Mode {
       let temp_highlight = this.highlighted_cell_one;
       this.clear();
       this.highlighted_cell_one = temp_highlight;
-      render_frame();
+      render_image_display();
     }
   }
 
@@ -414,7 +413,7 @@ class Mode {
       // two labels already selected, reselect second label
       this.handle_mode_multiple_click(evt);
     }
-    render_frame();
+    render_image_display();
   }
 
   //shows up in info display as text for "state:"
@@ -635,7 +634,7 @@ function render_info_display() {
   $('#mode').html(mode.render());
 }
 
-function render_edit(ctx) {
+function render_edit_image(ctx) {
   let hidden_canvas = document.getElementById('hidden_canvas');
 
   ctx.clearRect(0, 0, dimensions[0], dimensions[1]);
@@ -663,7 +662,7 @@ function render_edit(ctx) {
   ctx.restore();
 }
 
-function render_raw(ctx) {
+function render_raw_image(ctx) {
   ctx.clearRect(0, 0, dimensions, dimensions[1]);
   ctx.drawImage(raw_image, 0, 0, dimensions[0], dimensions[1]);
 
@@ -674,7 +673,7 @@ function render_raw(ctx) {
   ctx.putImageData(image_data, 0, 0);
 }
 
-function render_annotations(ctx) {
+function render_annotation_image(ctx) {
   ctx.clearRect(0, 0, dimensions[0], dimensions[1]);
   ctx.drawImage(seg_image, 0, 0, dimensions[0], dimensions[1]);
   if (current_highlight){
@@ -685,19 +684,19 @@ function render_annotations(ctx) {
   }
 }
 
-function render_frame() {
+function render_image_display() {
   let ctx = $('#canvas').get(0).getContext("2d");
   ctx.imageSmoothingEnabled = false;
 
   if (edit_mode) {
     // edit mode (annotations overlaid on raw + brush preview)
-    render_edit(ctx);
+    render_edit_image(ctx);
   } else if (rendering_raw) {
     // draw raw image
-    render_raw(ctx);
+    render_raw_image(ctx);
   } else {
     // draw annotations
-    render_annotations(ctx);
+    render_annotation_image(ctx);
   }
   render_info_display();
 }
@@ -711,9 +710,9 @@ function fetch_and_render_frame() {
       // array of arrays, contains annotation data for frame
       seg_array = payload.seg_arr;
       seg_image.src = payload.segmented;
-      seg_image.onload = render_frame;
+      seg_image.onload = render_image_display;
       raw_image.src = payload.raw;
-      raw_image.onload = render_frame;
+      raw_image.onload = render_image_display;
     },
     async: false
   });
@@ -757,7 +756,7 @@ function handle_scroll(evt) {
   if (rendering_raw || edit_mode) {
     let delta = - evt.originalEvent.deltaY / 2;
     current_contrast = Math.max(current_contrast + delta, -100);
-    render_frame();
+    render_image_display();
   }
 }
 
@@ -798,7 +797,7 @@ function handle_mousemove(evt) {
     brush.x = mouse_x;
     brush.y = mouse_y;
     brush.draw(hidden_ctx);
-    render_frame();
+    render_image_display();
   }
 }
 
@@ -875,7 +874,7 @@ function action(action, info, frame = current_frame) {
         }
       }
       if (payload.tracks || payload.imgs) {
-        render_frame();
+        render_image_display();
       }
     },
     async: false

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -119,22 +119,6 @@ class Mode {
       // toggle edit mode
       edit_mode = !edit_mode;
       render_image_display();
-    } else if (key === "f") {
-      // cycle forward one feature, if applicable
-      if (feature_max > 0) {
-        this.feature = this.increment_value(this.feature, 0, feature_max -1);
-        this.info = {"feature": this.feature};
-        action("change_feature", this.info);
-        this.clear();
-      }
-    } else if (key === "F") {
-      // cycle backward one feature, if applicable
-      if (feature_max > 0) {
-        this.feature = this.decrement_value(this.feature, 0, feature_max -1);
-        this.info = {"feature": this.feature};
-        action("change_feature", this.info);
-        this.clear();
-      }
     } else if (key === "c") {
       // cycle forward one channel, if applicable
       if (channel_max > 0) {
@@ -149,6 +133,22 @@ class Mode {
         this.channel = this.decrement_value(this.channel, 0, channel_max -1);
         this.info = {"channel": this.channel};
         action("change_channel", this.info);
+        this.clear();
+      }
+    } else if (key === "f") {
+      // cycle forward one feature, if applicable
+      if (feature_max > 0) {
+        this.feature = this.increment_value(this.feature, 0, feature_max -1);
+        this.info = {"feature": this.feature};
+        action("change_feature", this.info);
+        this.clear();
+      }
+    } else if (key === "F") {
+      // cycle backward one feature, if applicable
+      if (feature_max > 0) {
+        this.feature = this.decrement_value(this.feature, 0, feature_max -1);
+        this.info = {"feature": this.feature};
+        action("change_feature", this.info);
         this.clear();
       }
     } else if (key === "p") {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -122,26 +122,36 @@ class Mode {
       render_frame();
     } else if (key === "f") {
       // cycle forward one feature, if applicable
-      // TODO: clean up!
-      this.change_feature();
-      this.info = {"feature": this.feature};
-      action("change_feature", this.info);
-      this.clear();
-      //should also add in a shift-f keybind if we ever want to use more than 1 feature
+      if (feature_max > 0) {
+        this.feature = this.increment_value(this.feature, 0, feature_max -1);
+        this.info = {"feature": this.feature};
+        action("change_feature", this.info);
+        this.clear();
+      }
+    } else if (key === "F") {
+      // cycle backward one feature, if applicable
+      if (feature_max > 0) {
+        this.feature = this.decrement_value(this.feature, 0, feature_max -1);
+        this.info = {"feature": this.feature};
+        action("change_feature", this.info);
+        this.clear();
+      }
     } else if (key === "c") {
       // cycle forward one channel, if applicable
-      // TODO: clean up!
-      this.change_channel(true);
-      this.info = {"channel": this.channel};
-      action("change_channel", this.info);
-      this.clear();
+      if (channel_max > 0) {
+        this.channel = this.increment_value(this.channel, 0, channel_max -1);
+        this.info = {"channel": this.channel};
+        action("change_channel", this.info);
+        this.clear();
+      }
     } else if (key === "C") {
       // cycle backward one channel, if applicable
-      // TODO: clean up!
-      this.change_channel(false);
-      this.info = {"channel": this.channel};
-      action("change_channel", this.info);
-      this.clear();
+      if (channel_max > 0) {
+        this.channel = this.decrement_value(this.channel, 0, channel_max -1);
+        this.info = {"channel": this.channel};
+        action("change_channel", this.info);
+        this.clear();
+      }
     } else if (key === "p") {
       //iou cell identity prediction
       this.kind = Modes.question;
@@ -150,19 +160,13 @@ class Mode {
       render_log();
     } else if (key === "-" && this.highlighted_cell_one !== -1) {
       // cycle highlight to prev label
-      if (this.highlighted_cell_one === 1) {
-        this.highlighted_cell_one = maxLabelsMap.get(this.feature);
-      } else {
-        this.highlighted_cell_one -=1;
-      }
+      this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
+          1, maxLabelsMap.get(this.feature));
       render_frame();
     } else if (key === "=" && this.highlighted_cell_one !== -1) {
       // cycle highlight to next label
-      if (this.highlighted_cell_one === maxLabelsMap.get(this.feature)) {
-        this.highlighted_cell_one = 1;
-      } else {
-        this.highlighted_cell_one +=1;
-      }
+      this.highlighted_cell_one = this.increment_value(this.highlighted_cell_one,
+          1, maxLabelsMap.get(this.feature));
       render_frame();
     }
   }
@@ -191,11 +195,8 @@ class Mode {
       render_log();
     } else if (key === "-") {
       // cycle highlight to prev label
-      if (this.highlighted_cell_one === 1) {
-        this.highlighted_cell_one = maxLabelsMap.get(this.feature);
-      } else {
-        this.highlighted_cell_one -=1;
-      }
+      this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
+          1, maxLabelsMap.get(this.feature));
       // clear info but show new highlighted cell
       let temp_highlight = this.highlighted_cell_one;
       this.clear();
@@ -203,11 +204,8 @@ class Mode {
       render_frame();
     } else if (key === "=") {
       // cycle highlight to next label
-      if (this.highlighted_cell_one === maxLabelsMap.get(this.feature)) {
-        this.highlighted_cell_one = 1;
-      } else {
-        this.highlighted_cell_one +=1;
-      }
+      this.highlighted_cell_one = this.increment_value(this.highlighted_cell_one,
+          1, maxLabelsMap.get(this.feature));
       // clear info but show new highlighted cell
       let temp_highlight = this.highlighted_cell_one;
       this.clear();
@@ -304,30 +302,24 @@ class Mode {
     this.clear()
   }
 
-  change_feature(){
-    if (this.feature < feature_max - 1) {
-      this.feature += 1;
+  // helper function to increment value but cycle around if needed
+  increment_value(currentValue, minValue, maxValue) {
+    if (currentValue < maxValue) {
+      currentValue += 1;
     } else {
-      this.feature = 0;
+      currentValue = minValue;
     }
+    return currentValue;
   }
 
-  change_channel(cycle_forward){
-    if (cycle_forward) {
-      if (this.channel < channel_max - 1) {
-        this.channel += 1;
-      } else {
-        this.channel = 0;
-      }
-
+  // helper function to decrement value but cycle around if needed
+  decrement_value(currentValue, minValue, maxValue) {
+    if (currentValue > minValue) {
+      currentValue -= 1;
     } else {
-      if (this.channel > 0) {
-        this.channel -= 1;
-      } else {
-        this.channel = channel_max - 1;
-      }
+      currentValue = maxValue;
     }
-
+    return currentValue;
   }
 
   click(evt) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -551,9 +551,15 @@ function invert(img) {
 }
 
 function label_under_mouse() {
-  let img_y = Math.floor(mouse_y/scale) //image has been scaled by 2x
-  let img_x = Math.floor(mouse_x/scale)
-  let new_label = seg_array[img_y][img_x]; //check array value at mouse location
+  let img_y = Math.floor(mouse_y/scale);
+  let img_x = Math.floor(mouse_x/scale);
+  let new_label;
+  if (img_y >= 0 && img_y < seg_array.length &&
+      img_x >= 0 && img_x < seg_array[0].length) {
+    new_label = seg_array[img_y][img_x]; //check array value at mouse location
+  } else {
+    new_label = 0;
+  }
   return new_label;
 }
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -244,29 +244,58 @@ class Mode {
         action("flood_cell", this.info);
       } else if (this.action === "trim_pixels") {
         action("trim_pixels", this.info);
-      } else if (this.action === "create_new"){
+      } else if (this.action === "create_new") {
         action("new_cell_stack", this.info);
       } else if (this.action === "delete") {
         action("delete", this.info);
       } else if (this.action === "predict") {
         action("predict_zstack", this.info);
       } else if (this.action === "replace") {
-        action("replace", this.info);
+        if (this.info.label_1 !== this.info.label_2) {
+          let send_info = {"label_1": this.info.label_1,
+                          "label_2": this.info.label_2};
+          action("replace", send_info);
+        }
       } else if (this.action === "swap_cells") {
-        action("swap_all_frame", this.info);
+        if (this.info.label_1 !== this.info.label_2) {
+          let send_info = {"label_1": this.info.label_1,
+                          "label_2": this.info.label_2};
+          action("swap_all_frame", send_info);
+        }
       } else if (this.action === "watershed") {
-        action("watershed", this.info);
+        if (this.info.label_1 === this.info.label_2 &&
+            this.info.frame_1 === this.info.frame_2) {
+          this.info.frame = this.info.frame_1;
+          this.info.label = this.info.label_1;
+          delete this.info.frame_1;
+          delete this.info.frame_2;
+          delete this.info.label_1;
+          delete this.info.label_2;
+          action(this.action, this.info);
+        }
       }
       this.clear();
     } else if (key === "s") {
-      if(this.action === "create_new"){
+      if(this.action === "create_new") {
         action("new_single_cell", this.info);
       } else if (this.action === "predict") {
         action("predict_single", {"frame": current_frame});
       } else if (this.action === "replace") {
-        action("replace_single", this.info);
-      } else if (this.action === "swap_cells"){
-        action("swap_single_frame", this.info);
+        if (this.info.label_1 !== this.info.label_2 &&
+            this.info.frame_1 === this.info.frame_2) {
+          let send_info = {"label_1": this.info.label_1,
+                            "label_2": this.info.label_2,
+                            "frame": this.info.frame_1};
+          action("replace_single", send_info);
+        }
+      } else if (this.action === "swap_cells") {
+        if (this.info.label_1 !== this.info.label_2 &&
+            this.info.frame_1 === this.info.frame_2) {
+          let send_info = {"label_1": this.info.label_1,
+                            "label_2": this.info.label_2,
+                            "frame": this.info.frame_1};
+          action("swap_single_frame", send_info);
+        }
       }
       this.clear();
     }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -563,20 +563,7 @@ function label_under_mouse() {
   return new_label;
 }
 
-function render_log() {
-  current_label = label_under_mouse();
-
-  $('#frame').html(current_frame);
-  if (current_label != 0) {
-    $('#label').html(current_label);
-  } else {
-    $('#label').html("");
-  }
-
-
-  $('#feature').html(mode.feature);
-  $('#channel').html(mode.channel);
-
+function render_highlight_info() {
   if (current_highlight) {
     $('#highlight').html("ON");
     if (mode.highlighted_cell_one !== -1) {
@@ -593,7 +580,9 @@ function render_log() {
     $('#highlight').html("OFF");
     $('#currently_highlighted').html("none");
   }
+}
 
+function render_edit_info() {
   if (edit_mode) {
     $('#edit_mode').html("ON");
     $('#edit_brush_row').css('visibility', 'visible');
@@ -615,13 +604,34 @@ function render_log() {
     $('#edit_label_row').css('visibility', 'hidden');
     $('#edit_erase_row').css('visibility', 'hidden');
   }
+}
 
+function render_cell_info() {
+  current_label = label_under_mouse();
   if (current_label !== 0) {
+    $('#label').html(current_label);
     let track = tracks[mode.feature][current_label.toString()];
     $('#slices').text(track.slices.toString());
   } else {
+    $('#label').html("");
     $('#slices').text("");
   }
+}
+
+// updates html display of side info panel
+function render_log() {
+  // always show current frame, feature, channel
+  $('#frame').html(current_frame);
+  $('#feature').html(mode.feature);
+  $('#channel').html(mode.channel);
+
+  render_highlight_info();
+
+  render_edit_info();
+
+  render_cell_info();
+
+  // always show 'state'
   $('#mode').html(mode.render());
 }
 

--- a/browser/templates/index_track.html
+++ b/browser/templates/index_track.html
@@ -71,6 +71,11 @@
               </tr>
 
               <tr>
+                <td>frames:</td>
+                <td><div id="frames"></div></td>
+              </tr>
+
+              <tr>
                 <td>parent:</td>
                 <td id="parent"></td>
               </tr>
@@ -81,8 +86,8 @@
               </tr>
 
               <tr>
-                <td>frames:</td>
-                <td><div id="frames"></div></td>
+                <td>frame div:</td>
+                <td id="frame_div"></td>
               </tr>
 
               <tr>

--- a/browser/templates/infopane.html
+++ b/browser/templates/infopane.html
@@ -12,9 +12,9 @@
 
     <p><strong>Mouse</strong> over a cell mask to see cell label and lineage information.</p>
 
-    <p><strong>Scroll Wheel</strong> | In raw image mode, scroll up/down to change the brightness of the image.&nbsp;</p>
+    <p><strong>Scroll Wheel</strong> | In raw image or edit mode, scroll up/down to change the brightness of the image.&nbsp;</p>
 
-    <p><strong>z</strong> | Switch between annotations and raw images; use this to check if your masks and labels match up to the actual cell image. In edit mode, does not change display, but allows you to adjust display of raw image with scroll wheel.</p>
+    <p><strong>z</strong> | Switch between annotations and raw images; use this to check if your masks and labels match up to the actual cell image.</p>
 
     <p><strong>e</strong> | Toggle between whole-label and pixel-editing modes. Note: this will not toggle between modes if anything is selected.</p>
 
@@ -22,9 +22,9 @@
 
     <p><em>To navigate through frames:</em></p>
 
-    <p><strong>a</strong> | Go back to previous frame</p>
+    <p><strong>a</strong> or <strong>left arrow key</strong> | Go back to previous frame</p>
 
-    <p><strong>d</strong> | Go forward to next frame</p>
+    <p><strong>d</strong> or <strong>right arrow key</strong> | Go forward to next frame</p>
 
     <h3><em>Whole-label mode (default)</em></h3>
 
@@ -35,6 +35,8 @@
     <p><strong>Click</strong> on a cell mask to select it.</p>
 
     <p><strong>h</strong> | Highlight mode; if used, this will highlight the cells that are selected with a red mask.</p>
+
+    <p><strong>p</strong> | Predict relationships (npz files only); if used, this will reassign labels across frames. Does not detect cell divisions in timelapse movies.</p>
 
     <p><em>Single-Click Edit Operations:</em></p>
 
@@ -50,7 +52,7 @@
 
     <p><strong>r</strong> | <em><u>replace</u></em>: click on one cell mask (cell A) then another (cell B). Hit “r” to replace all instances of cell B with cell A.</p>
 
-    <!-- <p><strong>p</strong> | <em><u>parent</u></em>: click on one cell mask (cell D) then another (cell E). Hit “p” to assign cell D as the parent of cell E. Cell D will now include cell E in its list of daughter cells, and cell E will list cell D as its parent.</p> -->
+    <p><strong>p</strong> | <em><u>parent</u></em> (tracked files only): click on one cell mask (cell D) then another (cell E). Hit “p” to assign cell D as the parent of cell E. Cell D will now include cell E in its list of daughter cells, and cell E will list cell D as its parent.</p>
 
     <p dir="ltr"><strong>s&nbsp;</strong>| <em><u>swap</u></em>: click on one cell mask (cell F) then another (cell G). Hit “s” to swap the cell values (does not swap parent/daughter information). This affects all frames of the movie.</p>
 
@@ -66,9 +68,9 @@
 
     <p><em>To change the size of the brush:</em></p>
 
-    <p><strong>, (comma)</strong> | Decrease the brush size</p>
+    <p><strong>down arrow key</strong> | Decrease the brush size</p>
 
-    <p><strong>. (period)</strong> | Increase the brush size</p>
+    <p><strong>up arrow key</strong> | Increase the brush size</p>
 
     <p><em>To change the value of the brush:</em></p>
 


### PR DESCRIPTION
Splits big, unwieldy functions like prepare_canvas into helper functions. Largely does not change functionality except for a few small improvements, which include:

- redundancy in some functions removed (eg, prepare_canvas had two separate bindings for mouse movement)
- logic before sending some actions reduces unnecessary server calls and chances of buggy behavior (eg, don't send an action to replace a label with itself)
- assigning the same daughter to a parent more than once no longer produces duplicate daughter entries
- limiting how much users can manually increment edit_value of brush may reduce skipped labels
- label_under_mouse would sometimes log errors to the console when mouse moved over edges of canvas, when reported location was out of bounds of seg_array (not noticeable unless the console was open during use), fixed by checking mouse location against seg_array dimensions first
- frames_changed set to true upon changing channels or features in npz mode
- brush size keybinds changed to up/down arrow keys

Other changes include:

- large functions split into manageable helper functions grouped by use case (eg, keybinds that apply only in edit mode)
- left and right arrow keys also change frames (a and d still work as before)
- render_log renamed to render_info_display and render_frame renamed to render_image_display for clarity
- actions reordered in frontend and backend to have groupings similar to order of keybinds, order of actions is consistent between frontend and backend
