### PR TITLE
Refactor, document desktop npz class

### DIFF
--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1028,7 +1028,7 @@ class ZStackReview:
         '''
 
         if not self.edit_mode:
-            label = int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+            label = self.get_label()
             if self.mode.kind is None:
                 self.mouse_press_none_helper(modifiers, label)
             elif self.mode.kind == "SELECTED":
@@ -1150,7 +1150,7 @@ class ZStackReview:
             self.mode (resets to Mode.none())
         '''
         # which label was clicked on
-        label = int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+        label = self.get_label()
         if label != 0:
             self.edit_value = label
         self.mode = Mode.none()
@@ -1170,7 +1170,7 @@ class ZStackReview:
             self.mode to move to next step of conversion brush setting
         '''
         # which label was clicked on
-        label = int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+        label = self.get_label()
         if label != 0:
             self.conversion_brush_target = label
             # once value is set, move to setting next value
@@ -1191,7 +1191,7 @@ class ZStackReview:
             self.mode to enter use of conversion brush
         '''
         # which label was clicked on
-        label = int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+        label = self.get_label()
         if label != 0:
             self.conversion_brush_value = label
             # once value is set, turn on conversion brush
@@ -2093,6 +2093,15 @@ class ZStackReview:
         else:
             return self.annotated[self.current_frame,:,:,self.feature]
 
+    def get_label(self):
+        '''
+        Helper function that returns the label currently being hovered over.
+        Currently, this helper function just provides a nice little abstraction,
+        but this could also help the existing code stay flexible with additional
+        data formats.
+        '''
+        return int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+
     def draw_line(self):
         '''
         Draw thin white lines around the area of the window where the image
@@ -2143,7 +2152,7 @@ class ZStackReview:
         at the bottom of the information column.
         '''
         # value of annotation at current position of mouse
-        label = int(self.annotated[self.current_frame,self.y,self.x,self.feature])
+        label = self.get_label()
 
         if label != 0:
             cell_info = self.cell_info[self.feature][label].copy()

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -961,6 +961,12 @@ class ZStackReview:
         self.window.on_mouse_drag = self.on_mouse_drag
         self.window.on_mouse_release = self.on_mouse_release
 
+        # KeyStateHandler can be queried as dict during other events
+        # to check which keys are being held down
+        # expands potential use of modifiers during different mouse events
+        self.key_states = key.KeyStateHandler()
+        self.window.push_handlers(self.key_states)
+
         self.current_frame = 0
         self.draw_raw = False
         self.max_intensity = {}
@@ -1580,19 +1586,17 @@ class ZStackReview:
         self.mode to a new Mode object requires a secondary action, often a keybind,
         to confirm. When actions are carried out, self.mode is reset to Mode.none().
 
+        Note: this event handler is called when the key is pressed down. Holding down
+        or releasing keys do not affect this event handler. For keys that are being held
+        down at time of other events, query self.key_states[key], which makes use of
+        pyglet's KeyStateHandler class.
+
         Uses:
             symbol: integer representation of keypress, compare against pyglet.window.key
                 (modifiers do not affect symbol, so "a" and "A" are both key.A)
             modifiers: keys like shift, ctrl that are held down at the time of keypress
             (see pyglet docs for further explanation of these inputs and list of modifiers)
         '''
-        # TODO: on_key_press for any key registers it as being held down
-        # which is changed back on_key_release
-        # this would allow other types of actions to be modified
-        # eg, hold spacebar while clicking and dragging to pan screen,
-        # or hold shift while scrolling mouse wheel to change minimum brightness
-        # (I think) -- KeyStateHandler might be this
-
         # always carried out regardless of context
         self.universal_keypress_helper(symbol, modifiers)
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1538,10 +1538,24 @@ class ZStackReview:
         self.draw_label()
 
     def scale_screen(self):
-        #User can resize window and images will expand to fill space if possible
-        #Determine whether to base scale factor on width or height
+        '''
+        Recalculate scaling factor for image display. Calculates largest
+        integer scaling factor that can be applied to both height and width
+        of the image, to best use the available window space. If image size
+        is larger than available window space, scale factor will be set to 1
+        and image/window will extend off-screen: for this reason, it is recommended
+        that large images are reshaped or trimmed before editing in Caliban.
+
+        Uses:
+            self.window.height, self.window.width, and self.sidebar_width to determine
+                free window space
+            self.height and self.width (image dimensions) to calculate scale factor
+            self.scale_factor is updated with the smaller of the two scale factors
+                (or 1, whichever is largest)
+        '''
+        # user can resize window and images will expand to fill space if possible
         y_scale = self.window.height // self.height
-        x_scale = (self.window.width - 300) // self.width
+        x_scale = (self.window.width - self.sidebar_width) // self.width
         self.scale_factor = min(y_scale, x_scale)
         self.scale_factor = max(1, self.scale_factor)
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -2089,11 +2089,35 @@ class ZStackReview:
             return self.annotated[self.current_frame]
 
     def draw_line(self):
-        pyglet.graphics.draw(4, pyglet.gl.GL_LINES,
-            ("v2f", (self.sidebar_width, self.window.height,
+        '''
+        Draw thin white lines around the area of the window where the image
+        is being displayed. Distinguishes interactable portion of window from
+        information display more clearly but has no other purpose.
+
+        Uses:
+            self.scale_factor, self.width, self.height to calculate area of
+                window where image is being displayed
+            self.sidebar_width to offset lines appropriately
+        '''
+
+        # either one vertical line to separate left edge of image from sidebar
+        # or box around whole image (but I'm leaning towards box)
+        # TODO: need box to be 1 pixel removed from each edge because drawing it at
+        # these exact height slightly obscures the image itself--less of a problem
+        # at larger scales, more of a problem at scale_factor = 1 or 2
+
+        frame_width = self.scale_factor * self.width
+        frame_height = self.scale_factor * self.height
+
+        pyglet.graphics.draw(8, pyglet.gl.GL_LINES,
+            ("v2f", (self.sidebar_width, frame_height,
                      self.sidebar_width, 0,
                      self.sidebar_width, 0,
-                     self.window.width, 0))
+                     self.sidebar_width + frame_width, 0,
+                     self.sidebar_width + frame_width, 0,
+                     self.sidebar_width + frame_width, frame_height,
+                     self.sidebar_width + frame_width, frame_height,
+                     self.sidebar_width, frame_height))
         )
 
     def draw_label(self):

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -2474,7 +2474,6 @@ class ZStackReview:
             self.add_cell_info(feature = self.feature, add_label = label_1, frame = self.current_frame)
             self.del_cell_info(feature = self.feature, del_label = label_2, frame = self.current_frame)
 
-
     def action_replace(self):
         """
         Replacing label_2 with label_1. Overwrites every label_2 in the npz
@@ -2494,7 +2493,6 @@ class ZStackReview:
                     annotated[annotated == label_2] = label_1
                     self.add_cell_info(feature = self.feature, add_label = label_1, frame = frame)
                     self.del_cell_info(feature = self.feature, del_label = label_2, frame = frame)
-
 
     def action_swap_all(self):
         label_1 = self.mode.label_1
@@ -2861,7 +2859,6 @@ class ZStackReview:
             np.savez(save_file, X = self.raw, y = self.annotated)
         self.save_version += 1
 
-
     def add_cell_info(self, feature, add_label, frame):
         '''
         helper function for actions that add a cell to the npz
@@ -2884,7 +2881,6 @@ class ZStackReview:
 
                 self.num_cells[feature] += 1
 
-
     def del_cell_info(self, feature, del_label, frame):
         '''
         helper function for actions that remove a cell from the npz
@@ -2902,7 +2898,6 @@ class ZStackReview:
                 #also remove from list of cell_ids
                 ids = self.cell_ids[feature]
                 self.cell_ids[feature] = np.delete(ids, np.where(ids == np.int64(del_label)))
-
 
     def create_cell_info(self, feature):
         '''
@@ -2934,7 +2929,6 @@ class ZStackReview:
             cell_info["parent"] = None
             cell_info["capped"] = False
             cell_info["frames"] = self.cell_info[self.feature][cell]['frames']
-
 
     def save_as_trk(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1071,27 +1071,9 @@ class ZStackReview:
 
                 # color picking for conversion brush
                 elif self.mode.kind == "PROMPT" and self.mode.action == "CONVERSION BRUSH TARGET":
-                    # pick the color you will be writing over with conversion brush
-                    frame = self.annotated[self.current_frame]
-                    label = int(frame[self.y, self.x, self.feature])
-                    if label == 0:
-                        pass
-                    elif label != 0:
-                        self.conversion_brush_target = label
-                        self.mode = Mode("PROMPT", action = "CONVERSION BRUSH VALUE")
+                    self.pick_conversion_target_helper()
                 elif self.mode.kind == "PROMPT" and self.mode.action == "CONVERSION BRUSH VALUE":
-                    # pick the color the conversion brush will be drawing
-                    frame = self.annotated[self.current_frame]
-                    label = int(frame[self.y, self.x, self.feature])
-                    if label == 0:
-                        pass
-                    elif label != 0:
-                        self.conversion_brush_value = label
-                        self.mode = Mode.none()
-                        self.mode = Mode("DRAW", action = "CONVERSION",
-                            conversion_brush_target = self.conversion_brush_target,
-                            conversion_brush_value = self.conversion_brush_value)
-
+                    self.pick_conversion_value_helper()
                 # start drawing bounding box for threshold prediction
                 elif self.mode.kind == "PROMPT" and self.mode.action == "DRAW BOX":
                     self.predict_seed_1 = (self.y, self.x)
@@ -1113,6 +1095,50 @@ class ZStackReview:
         if label != 0:
             self.edit_value = label
         self.mode = Mode.none()
+
+    def pick_conversion_target_helper(self):
+        '''
+        Click on a label while setting up conversion brush to choose "target"
+        (label that will be overwritten by the conversion brush). Nothing happens
+        if background is clicked on (remain in conversion brush target-picking mode,
+        as opposed to normal color-picking). When color is picked, move to next
+        step in setting conversion brush.
+
+        Uses:
+            self.annotated, self.current_frame, self.y, self.x, and self.feature
+                to determine which label was clicked on
+            self.conversion_brush_target to store clicked value
+            self.mode to move to next step of conversion brush setting
+        '''
+        # which label was clicked on
+        label = int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+        if label != 0:
+            self.conversion_brush_target = label
+            # once value is set, move to setting next value
+            self.mode = Mode("PROMPT", action = "CONVERSION BRUSH VALUE")
+
+    def pick_conversion_value_helper(self):
+        '''
+        Click on a label while setting up conversion brush to choose "value"
+        (label that will be drawn by the conversion brush). Nothing happens
+        if background is clicked on (remain in conversion brush value-picking mode,
+        as with conversion brush target-picking). After label is picked, conversion
+        brush is set and will be in use.
+
+        Uses:
+            self.annotated, self.current_frame, self.y, self.x, and self.feature
+                to determine which label was clicked on
+            self.conversion_brush_value to store clicked value
+            self.mode to enter use of conversion brush
+        '''
+        # which label was clicked on
+        label = int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+        if label != 0:
+            self.conversion_brush_value = label
+            # once value is set, turn on conversion brush
+            self.mode = Mode("DRAW", action = "CONVERSION",
+                conversion_brush_target = self.conversion_brush_target,
+                conversion_brush_value = self.conversion_brush_value)
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1067,13 +1067,7 @@ class ZStackReview:
 
                 # color pick tool
                 elif self.mode.kind == "PROMPT" and self.mode.action == "PICK COLOR":
-                    frame = self.annotated[self.current_frame]
-                    label = int(frame[self.y, self.x, self.feature])
-                    if label == 0:
-                        self.mode = Mode.none()
-                    elif label != 0:
-                        self.edit_value = label
-                        self.mode = Mode.none()
+                    self.handle_color_pick_helper()
 
                 # color picking for conversion brush
                 elif self.mode.kind == "PROMPT" and self.mode.action == "CONVERSION BRUSH TARGET":
@@ -1102,6 +1096,23 @@ class ZStackReview:
                 elif self.mode.kind == "PROMPT" and self.mode.action == "DRAW BOX":
                     self.predict_seed_1 = (self.y, self.x)
 
+    def handle_color_pick_helper(self):
+        '''
+        Takes the label clicked on, sets self.edit_value to that label, and then
+        exits color-picking mode. Doesn't change anything if click on background
+        but still exits color-picking mode.
+
+        Uses:
+            self.annotated, self.current_frame, self.y, self.x, and self.feature
+                to determine which label was clicked on
+            self.edit_value (modifies stored value)
+            self.mode (resets to Mode.none())
+        '''
+        # which label was clicked on
+        label = int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+        if label != 0:
+            self.edit_value = label
+        self.mode = Mode.none()
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -41,10 +41,9 @@ import tempfile
 
 from io import BytesIO
 from skimage.morphology import watershed, flood_fill, flood
-from skimage.draw import circle, line_aa
+from skimage.draw import circle
 from skimage.measure import regionprops
 from skimage.exposure import rescale_intensity, equalize_adapthist
-from skimage.segmentation import active_contour
 from skimage import color, img_as_float, filters
 from skimage.util import invert
 
@@ -993,8 +992,6 @@ class ZStackReview:
         self.erase = False
         self.brush_view = np.zeros(self.annotated[self.current_frame,:,:,self.feature].shape)
         self.composite_view = np.zeros((1,self.height,self.width,3))
-        self.predict_coordinates = None
-        self.show_prediction = False
         self.show_brush = True
         self.predict_seed_1 = None
         self.predict_seed_2 = None
@@ -1104,18 +1101,6 @@ class ZStackReview:
                 # start drawing bounding box for threshold prediction
                 elif self.mode.kind == "PROMPT" and self.mode.action == "DRAW BOX":
                     self.predict_seed_1 = (self.y, self.x)
-
-                # active contour prediction
-                elif self.mode.kind == "PROMPT" and self.mode.action == "START SNAKE":
-                    self.show_brush = False
-                    self.predict_seed_1 = (self.y, self.x)
-                    self.mode = Mode("PROMPT", action = "END SNAKE")
-                elif self.mode.kind == "PROMPT" and self.mode.action == "END SNAKE":
-                    self.predict_seed_2 = (self.y, self.x)
-                    if self.predict_seed_2 != self.predict_seed_1:
-                        self.action_show_contour()
-                    self.mode = Mode.none()
-                    self.show_brush = True
 
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
@@ -1305,16 +1290,6 @@ class ZStackReview:
                 brush_area = circle(self.y, self.x, self.brush_size, (self.height,self.width))
                 self.brush_view[brush_area] = brush_val
 
-            if self.mode.kind is not None:
-                if not self.show_brush and self.mode.action == "END SNAKE":
-                    self.brush_view = np.zeros(self.annotated[self.current_frame,:,:,self.feature].shape)
-
-                    # show contour line as it is being drawn
-                    y_start, x_start = self.predict_seed_1
-                    y_end, x_end = self.y, self.x
-
-                    rr, cc, val = line_aa(y_start, x_start, y_end, x_end)
-                    self.brush_view[rr,cc] = val*255
 
     def on_draw(self):
         self.window.clear()
@@ -1352,18 +1327,12 @@ class ZStackReview:
 
         if symbol in {key.LEFT, key.A}:
             self.current_frame = max(self.current_frame - offset, 0)
-            #clear prediction if you change frames so you aren't working
-            #from the wrong prediction
-            self.show_prediction = False
-            self.predict_coordinates = None
             # if you change frames while you've viewing composite, update composite
             if self.edit_mode and not self.hide_annotations:
                 self.helper_update_composite()
 
         elif symbol in {key.RIGHT, key.D}:
             self.current_frame = min(self.current_frame + offset, self.num_frames - 1)
-            self.show_prediction = False
-            self.predict_coordinates = None
             # if you change frames while you've viewing composite, update composite
             if self.edit_mode and not self.hide_annotations:
                 self.helper_update_composite()
@@ -1448,11 +1417,6 @@ class ZStackReview:
             elif self.mode.kind == "SELECTED":
                 self.mode = Mode("QUESTION",
                                 action="CREATE NEW", **self.mode.info)
-            elif self.edit_mode:
-                # clear and stop showing prediction view
-                self.show_prediction = False
-                self.predict_coordinates = None
-                self.helper_update_composite()
 
         if symbol == key.E:
             #toggle edit mode only if nothing is selected
@@ -1472,9 +1436,6 @@ class ZStackReview:
             if self.mode.kind == "SELECTED":
                 self.mode = Mode("PROMPT",
                                 action="FILL HOLE", **self.mode.info)
-        if symbol == key.L:
-            if self.mode.kind is None and self.edit_mode:
-                self.mode = Mode("PROMPT", action = "START SNAKE")
 
         if symbol == key.S:
             if self.mode.kind is None and not self.edit_mode:
@@ -1944,44 +1905,6 @@ class ZStackReview:
 
         return ann_threshold
 
-    def action_show_contour(self):
-        '''
-        placeholder for previewing predicted skimage contour between cells
-        for now, just shows that you picked a line to base the contour on
-        '''
-        y_start, x_start = self.predict_seed_1
-        y_end, x_end = self.predict_seed_2
-
-        rr, cc, val = line_aa(y_start, x_start, y_end, x_end)
-
-        self.predict_coordinates = (rr, cc)
-
-        self.show_prediction = True
-        self.draw_current_frame()
-
-        #double the number of points we have to work with for a fuller output snake
-        input_snake = np.array([np.concatenate((cc, cc)), np.concatenate((rr, rr))]).T
-
-        # skimage docs recommend blurring input image, just blur a little
-        snake_predict = active_contour(image = filters.gaussian(self.raw[self.current_frame, :,:, self.channel], 0.3),
-            snake = input_snake,
-            alpha=0.01,
-            beta=100,
-            w_line=-5,
-            w_edge=0,
-            gamma=0.01,
-            bc='fixed',
-            max_px_move=0.15,
-            max_iterations=1000,
-            convergence=0.1)
-
-        self.predict_coordinates = snake_predict.T.astype('int')
-        self.predict_coordinates = (self.predict_coordinates[1], self.predict_coordinates[0])
-
-        if not self.hide_annotations:
-            self.helper_update_composite()
-        self.draw_current_frame()
-
     def action_delete_mask(self):
         '''
         remove selected annotation from frame, replacing with zeros
@@ -2184,14 +2107,6 @@ class ZStackReview:
         # with that of the color mask
         img_hsv[..., 0] = color_mask_hsv[..., 0]
         img_hsv[..., 1] = color_mask_hsv[..., 1] * alpha
-
-        # if we're displaying a prediction preview, it should show up as
-        # contrasting colors (hsv[rr, cc, 0] adjustment) and bright
-        # (saturation high). add to composite img instead of overlaying with sprites
-        if self.show_prediction:
-            rr, cc = self.predict_coordinates
-            img_hsv[rr, cc, 0] = color_mask_hsv[rr, cc, 0] + 0.5
-            img_hsv[rr, cc, 1] = 1
 
         img_masked = color.hsv2rgb(img_hsv)
         img_masked = rescale_intensity(img_masked, out_range = np.uint8)

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -2257,40 +2257,42 @@ class ZStackReview:
         '''
         helper function for actions that add a cell to the npz
         '''
-        #if cell already exists elsewhere in npz:
-        try:
-            old_frames = self.cell_info[feature][add_label]['frames']
-            updated_frames = np.append(old_frames, frame)
-            updated_frames = np.unique(updated_frames).tolist()
-            self.cell_info[feature][add_label].update({'frames': updated_frames})
-        #cell does not exist anywhere in npz:
-        except KeyError:
-            self.cell_info[feature].update({add_label: {}})
-            self.cell_info[feature][add_label].update({'label': str(add_label)})
-            self.cell_info[feature][add_label].update({'frames': [frame]})
-            self.cell_info[feature][add_label].update({'slices': ''})
+        if add_label != 0:
+            #if cell already exists elsewhere in npz:
+            try:
+                old_frames = self.cell_info[feature][add_label]['frames']
+                updated_frames = np.append(old_frames, frame)
+                updated_frames = np.unique(updated_frames).tolist()
+                self.cell_info[feature][add_label].update({'frames': updated_frames})
+            #cell does not exist anywhere in npz:
+            except KeyError:
+                self.cell_info[feature].update({add_label: {}})
+                self.cell_info[feature][add_label].update({'label': str(add_label)})
+                self.cell_info[feature][add_label].update({'frames': [frame]})
+                self.cell_info[feature][add_label].update({'slices': ''})
 
-            self.cell_ids[feature] = np.append(self.cell_ids[feature], add_label)
+                self.cell_ids[feature] = np.append(self.cell_ids[feature], add_label)
 
-            self.num_cells[feature] += 1
+                self.num_cells[feature] += 1
 
 
     def del_cell_info(self, feature, del_label, frame):
         '''
         helper function for actions that remove a cell from the npz
         '''
-        #remove cell from frame
-        old_frames = self.cell_info[feature][del_label]['frames']
-        updated_frames = np.delete(old_frames, np.where(old_frames == np.int64(frame))).tolist()
-        self.cell_info[feature][del_label].update({'frames': updated_frames})
+        if del_label != 0:
+            #remove cell from frame
+            old_frames = self.cell_info[feature][del_label]['frames']
+            updated_frames = np.delete(old_frames, np.where(old_frames == np.int64(frame))).tolist()
+            self.cell_info[feature][del_label].update({'frames': updated_frames})
 
-        #if that was the last frame, delete the entry for that cell
-        if self.cell_info[feature][del_label]['frames'] == []:
-            del self.cell_info[feature][del_label]
+            #if that was the last frame, delete the entry for that cell
+            if self.cell_info[feature][del_label]['frames'] == []:
+                del self.cell_info[feature][del_label]
 
-            #also remove from list of cell_ids
-            ids = self.cell_ids[feature]
-            self.cell_ids[feature] = np.delete(ids, np.where(ids == np.int64(del_label)))
+                #also remove from list of cell_ids
+                ids = self.cell_ids[feature]
+                self.cell_ids[feature] = np.delete(ids, np.where(ids == np.int64(del_label)))
 
 
     def create_cell_info(self, feature):

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1496,7 +1496,7 @@ class ZStackReview:
             # self.max_intensity[self.channel] is initialized as None, set to value
             # based on maximum brightness of image
             if self.max_intensity[self.channel] is None:
-                self.max_intensity[self.channel] = np.max(self.get_current_frame()[:,:,self.channel])
+                self.max_intensity[self.channel] = np.max(self.get_current_frame())
             # self.max_intensity[self.channel] has a value so we can adjust it
             else:
                 # check minimum brightness of image as lower bound of brightness adjustment
@@ -2083,10 +2083,15 @@ class ZStackReview:
                 self.mode = Mode.none()
 
     def get_current_frame(self):
+        '''
+        Helper function that returns the frame currently being viewed.
+        Used for drawing the image in label-editing mode, and for adjusting
+        the brightness of the raw image with the mouse scroll wheel.
+        '''
         if self.draw_raw:
-            return self.raw[self.current_frame]
+            return self.raw[self.current_frame,:,:,self.channel]
         else:
-            return self.annotated[self.current_frame]
+            return self.annotated[self.current_frame,:,:,self.feature]
 
     def draw_line(self):
         '''
@@ -2284,7 +2289,7 @@ class ZStackReview:
 
         # create pyglet image from raw array info, using brightness and cmap settings
         if self.draw_raw:
-            image = self.helper_array_to_img(input_array = frame[:,:,self.channel],
+            image = self.helper_array_to_img(input_array = frame,
                                                      vmax = self.max_intensity[self.channel],
                                                      cmap = self.cmap_options[self.current_cmap],
                                                      output = 'pyglet')
@@ -2302,7 +2307,7 @@ class ZStackReview:
                 frame = self.apply_label_highlight_helper(frame)
 
             # create pyglet image
-            image = self.helper_array_to_img(input_array = frame[:,:,self.feature],
+            image = self.helper_array_to_img(input_array = frame,
                                                     vmax = max(1,np.max(self.cell_ids[self.feature]) + self.adjustment[self.feature]),
                                                     cmap = cmap,
                                                     output = 'pyglet')
@@ -2826,7 +2831,7 @@ class ZStackReview:
             vmax = 1
         elif not self.adapthist_on:
             if self.draw_raw and self.max_intensity[self.channel] is None:
-                self.max_intensity[self.channel] = np.max(self.get_current_frame()[:,:,self.channel])
+                self.max_intensity[self.channel] = np.max(self.get_current_frame())
             vmax = self.max_intensity[self.channel]
 
         raw_img =  self.helper_array_to_img(input_array = current_raw,

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1159,6 +1159,12 @@ class ZStackReview:
         if self.edit_mode:
             if self.show_brush:
                 self.brush_view = np.zeros(self.annotated[self.current_frame,:,:,self.feature].shape)
+                brush_area = circle(self.y, self.x, self.brush_size, (self.height,self.width))
+                if self.mode.kind == "DRAW":
+                    self.brush_view[brush_area] = self.conversion_brush_value
+                else:
+                    self.brush_view[brush_area] = self.edit_value
+
             if self.mode.kind is not None:
                 if not self.show_brush and self.mode.action == "DRAW BOX":
                     #releasing the mouse is the cue to finalize the bounding box

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -990,6 +990,9 @@ class ZStackReview:
         self.window.on_mouse_drag = self.on_mouse_drag
         self.window.on_mouse_release = self.on_mouse_release
 
+        # add this handler instead of replacing the default on_resize handler
+        self.window.push_handlers(self.on_resize)
+
         # KeyStateHandler can be queried as dict during other events
         # to check which keys are being held down
         # expands potential use of modifiers during different mouse events
@@ -1605,8 +1608,6 @@ class ZStackReview:
         '''
         # clear old information
         self.window.clear()
-        # TODO: move self.scale_screen into self.window.on_resize, which is more appropriate
-        self.scale_screen()
         # TODO: use a batch to consolidate all of the "drawing" calls
         # draw relevant image
         self.draw_current_frame()
@@ -1614,6 +1615,17 @@ class ZStackReview:
         self.draw_line()
         # draw information text in sidebar
         self.draw_label()
+
+    def on_resize(self, width, height):
+        '''
+        Event handler for when pyglet window changes size. Note: this
+        is pushed to the event handler stack instead of overwriting pyglet
+        default event handlers, as on_resize has other default behavior needed
+        to properly display screen. Calls scale_screen when window resized, as
+        this is the only occasion where we may need to update the screen scale
+        factor.
+        '''
+        self.scale_screen()
 
     def scale_screen(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1519,10 +1519,22 @@ class ZStackReview:
             self.helper_update_composite()
 
     def on_draw(self):
+        '''
+        Event handler for pyglet window, redraws all content of screen after
+        window events. Clears window, calculates screen scaling, then redraws
+        the displayed image, lines around that image (to distinguish from black
+        background of the rest of the window), and information text in the sidebar.
+        '''
+        # clear old information
         self.window.clear()
+        # TODO: move self.scale_screen into self.window.on_resize, which is more appropriate
         self.scale_screen()
+        # TODO: use a batch to consolidate all of the "drawing" calls
+        # draw relevant image
         self.draw_current_frame()
+        # draw lines around the image to distinguish it from rest of window
         self.draw_line()
+        # draw information text in sidebar
         self.draw_label()
 
     def scale_screen(self):

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1744,7 +1744,7 @@ class ZStackReview:
         # BRUSH VALUE ADJUSTMENT
         # increase brush value, caps at max value + 1
         if symbol == key.EQUAL:
-            self.edit_value = min(self.edit_value + 1, np.max(self.cell_ids[self.feature]) + 1)
+            self.edit_value = min(self.edit_value + 1, self.get_new_label())
             self.update_brushview_helper()
         # decrease brush value, can't decrease past 1
         if symbol == key.MINUS:
@@ -1752,7 +1752,7 @@ class ZStackReview:
             self.update_brushview_helper()
         # set brush to unused label
         if symbol == key.N:
-            self.edit_value = np.max(self.cell_ids[self.feature]) + 1
+            self.edit_value = self.get_new_label()
             self.update_brushview_helper()
 
         # TOGGLE ERASER
@@ -1811,7 +1811,7 @@ class ZStackReview:
         # TODO: update Mode prompt to reflect that you can do this
         if self.mode.kind == "PROMPT" and self.mode.action == "CONVERSION BRUSH VALUE":
             if symbol == key.N:
-                self.conversion_brush_value = np.max(self.cell_ids[self.feature]) + 1
+                self.conversion_brush_value = self.get_new_label()
                 self.mode = Mode("DRAW", action = "CONVERSION",
                         conversion_brush_target = self.conversion_brush_target,
                         conversion_brush_value = self.conversion_brush_value)
@@ -2110,6 +2110,22 @@ class ZStackReview:
         data formats.
         '''
         return int(self.annotated[self.current_frame, self.y, self.x, self.feature])
+
+    def get_new_label(self):
+        '''
+        Helper function that returns a new label (doesn't currently exist in
+        annotation feature). The new label is the highest label that currently
+        exists in the feature, plus 1, which will always be unused. Does not
+        ever return labels that have been skipped, although these labels are also
+        technically unused.
+
+        Uses:
+            self.cell_ids, which is a list of the labels present in file (does not
+                contain other information, as cell_info dict does); cell_ids is updated
+                when labels are added or removed from features, so this accurately
+                represents which labels are currently in use
+        '''
+        return int(np.max(self.cell_ids[self.feature]) + 1)
 
     def draw_line(self):
         '''
@@ -2467,7 +2483,7 @@ class ZStackReview:
                 is always made, no need to check these first)
         """
         old_label, single_frame = self.mode.label, self.mode.frame
-        new_label = np.max(self.cell_ids[self.feature]) + 1
+        new_label = self.get_new_label()
 
         # replace frame labels
         frame = self.annotated[single_frame,:,:,self.feature]
@@ -2494,7 +2510,7 @@ class ZStackReview:
                 before calling, since old label is only guaranteed to be in the frame it is selected in)
         """
         old_label, start_frame = self.mode.label, self.mode.frame
-        new_label = np.max(self.cell_ids[self.feature]) + 1
+        new_label = self.get_new_label()
 
         # replace frame labels
         for frame in self.annotated[start_frame:,:,:,self.feature]:
@@ -2671,7 +2687,7 @@ class ZStackReview:
 
         # Pull the label that is being split and find a new valid label
         current_label = self.mode.label_1
-        new_label = np.max(self.cell_ids[self.feature]) + 1
+        new_label = self.get_new_label()
 
         # Locally store the frames to work on
         img_raw = self.raw[self.current_frame,:,:,self.channel]
@@ -2739,7 +2755,7 @@ class ZStackReview:
         threshold_stringent = 1.10 * threshold
 
         # use a unique label for predction
-        new_label = np.max(self.cell_ids[self.feature]) + 1
+        new_label = self.get_new_label()
 
         # try to keep stray pixels from appearing with hysteresis approach
         hyst = filters.apply_hysteresis_threshold(image = predict_area,
@@ -2831,7 +2847,7 @@ class ZStackReview:
         # old label is definitely in original, check later if in modified
         old_label = self.mode.label
         # label used to flood area
-        new_label = np.max(self.cell_ids[self.feature]) + 1
+        new_label = self.get_new_label()
         # use frame where label was selected, not current frame
         frame = self.mode.frame
 

--- a/desktop/mode.py
+++ b/desktop/mode.py
@@ -39,9 +39,9 @@ class Mode:
                 ", ".join("{}={}".format(k, v) for k, v in self.info.items()) + ")")
 
     def render(self):
-        if self.kind is None:
-            return ''
-        answer = "(SPACE=YES / ESC=NO)"
+
+        text = ""
+        answer = "SPACE = CONFIRM\nESC = CANCEL"
 
         try:
             filetype = self.info['filetype']
@@ -49,65 +49,108 @@ class Mode:
             filetype = ""
 
         if self.kind == "SELECTED":
-            return "\nSELECTED {}".format(self.label)
+            text = "\nSELECTED {}".format(self.label)
+
         elif self.kind == "MULTIPLE":
-            return "\nSELECTED {}, {}".format(self.label_1, self.label_2)
+            text = "\nSELECTED {}, {}".format(self.label_1, self.label_2)
+
         elif self.kind == "QUESTION":
             if self.action == "SAVE":
                 if filetype == "npz":
-                    return ("\nSave current movie?\nSPACE=SAVE\nT=SAVE AS .TRK FILE\nESC=CANCEL")
+                    text = ("\nSave current movie?"
+                        "\nSPACE = SAVE"
+                        "\nT = SAVE AS .TRK FILE"
+                        "\nESC = CANCEL")
                 else:
-                    return ("\nSave current movie?\nSPACE=SAVE\nESC=CANCEL")
+                    text = ("\nSave current movie?"
+                        "\nSPACE = SAVE"
+                        "\nESC = CANCEL")
+
             elif self.action == "REPLACE":
-                return ("\nreplace {} with {}?\n {}".format(self.label_2, self.label_1,
-                 '\nSPACE = REPLACE IN ALL FRAMES\nS = REPLACE IN THIS FRAME ONLY\nESC = CANCEL REPLACE'))
+                text = ("\nReplace {} with {}?"
+                    "\nSPACE = REPLACE IN ALL FRAMES"
+                     "\nS = REPLACE IN FRAME {} ONLY"
+                     "\nESC = CANCEL").format(self.label_2, self.label_1, self.frame_2)
+
             elif self.action == "SWAP":
-                return ("\nswap {} & {}?\n{}".format(self.label_2, self.label_1,
-                '\nSPACE = SWAP IN ALL FRAMES\nS = SWAP IN THIS FRAME ONLY\nESC = CANCEL SWAP'))
+                if self.frame_1 == self.frame_2:
+                    text = ("\nSwap {} & {}?"
+                        "\nSPACE = SWAP IN ALL FRAMES"
+                        "\nS = SWAP IN FRAME {} ONLY"
+                        "\nESC = CANCEL").format(self.label_2, self.label_1, self.frame_2)
+                else:
+                    text = ("\nSwap {} & {}?"
+                        "\nSPACE = SWAP IN ALL FRAMES"
+                        "\nESC = CANCEL").format(self.label_2, self.label_1)
+
             elif self.action == "PARENT":
-                return ("\nmake {} a daughter of {}?\n {}".format(self.label_2, self.label_1, answer))
+                text = "\nMake {} a daughter of {}?\n{}".format(self.label_2, self.label_1, answer)
+
             elif self.action == "NEW TRACK":
-                return ("\ncreate new track from {} on frame {}?".format(self.label, self.frame) +
-                    "\n {}".format("(S=SINGLE FRAME / SPACE=ALL SUBSEQUENT FRAMES / ESC=NO)"))
+                text = ("\nCreate new track from {0} in frame {1}?"
+                    "\nSPACE = CREATE IN FRAME {1} AND ALL SUBSEQUENT FRAMES"
+                    "\nS = CREATE IN FRAME {1} ONLY"
+                    "\nESC = CANCEL").format(self.label, self.frame)
+
             elif self.action == "CREATE NEW":
-                return ("".format(self.label, self.frame)
-                        + "\n {}".format("(S=SINGLE FRAME / SPACE=ALL SUBSEQUENT FRAMES / ESC=NO)"))
+                text = ("\nCreate new label from {0} in frame {1}?"
+                    "\nSPACE = CREATE IN FRAME {1} AND ALL SUBSEQUENT FRAMES"
+                    "\nS = CREATE IN FRAME {1} ONLY"
+                    "\nESC = CANCEL").format(self.label, self.frame)
+
             elif self.action == "FLOOD CELL":
-                return('\nSPACE = FLOOD SELECTED CELL WITH NEW LABEL\nESC = CANCEL')
+                text = ("\nFlood selected region of {} with new label in frame {}?"
+                    "\n{}").format(self.label, self.frame, answer)
+
             elif self.action == "TRIM PIXELS":
-                return('\nSPACE = TRIM DISCONTIGUOUS PIXELS FROM CELL\nESC = CANCEL')
+                text = ("\nTrim unconnected pixels away from selected region of label {} in frame {}?"
+                    "\n{}").format(self.label, self.frame, answer)
+
             elif self.action == "DELETE":
-                return ('\nDelete label {} in frame {}?\n{}'.format(self.label, self.frame,
-                "SPACE = CONFIRM DELETION\nESC = CANCEL DELETION"))
+                text = ("\nDelete label {} in frame {}?"
+                    "\n{}").format(self.label, self.frame, answer)
+
             elif self.action == "WATERSHED":
-                return ("\nperform watershed to split {}?\n{}".format(self.label_1, answer))
+                text = ("\nPerform watershed to split {}?"
+                    "\n{}").format(self.label_1, answer)
+
             elif self.action == "PREDICT":
-                return ("Predict cell ids for zstack?\nS=PREDICT THIS FRAME\nSPACE=PREDICT ALL FRAMES\nESC=CANCEL PREDICTION")
+                text = ("\nPredict 3D relationships between labels?"
+                    "\nS = PREDICT THIS FRAME FROM PREVIOUS FRAME"
+                    "\nSPACE = PREDICT ALL FRAMES"
+                    "\nESC = CANCEL")
+
             elif self.action == "RELABEL":
-                return ("Relabel cells?\nSPACE=RELABEL ALL FRAMES\nP=PRESERVE 3D INFO\nS=RELABEL THIS FRAME ONLY\nU=UNIQUELY RELABEL EACH CELL\nESC=CANCEL")
+                text = ("\nRelabel annotations?"
+                    "\nSPACE = RELABEL IN ALL FRAMES"
+                    "\nP = PRESERVE 3D INFO WHILE RELABELING"
+                    "\nS = RELABEL THIS FRAME ONLY"
+                    "\nU = UNIQUELY RELABEL EACH LABEL"
+                    "\nESC = CANCEL")
+
         elif self.kind == "PROMPT":
             if self.action == "FILL HOLE":
-                return('\nselect hole to fill in cell {}'.format(self.label))
-            elif self.action == "PICK COLOR":
-                return('\nclick on a cell to change the brush value to that value')
-            elif self.action == "DRAW BOX":
-                return('\ndraw a bounding box around the area you want to threshold')
-            elif self.action == "START SNAKE":
-                return('\nclick to select a starting point for contour prediction')
-            elif self.action == "END SNAKE":
-                return('\nclick to select an ending point for contour prediction')
-            elif self.action == "CONVERSION BRUSH TARGET":
-                return('\nclick on the label you want to draw OVER')
-            elif self.action == "CONVERSION BRUSH VALUE":
-                return('\nclick on the label you want to draw WITH')
-        elif self.kind == "DRAW":
-            # return('\nusing conversion brush to replace {} with {}'.format(self.info['conversion_brush_target'],
-            #     self.info['conversion_brush_value']))
-            return('\nusing conversion brush to replace {} with {}\nuse ESC to leave this mode'.format(self.conversion_brush_target,
-                self.conversion_brush_value))
-        else:
-            return ''
+                text = "\nSelect hole to fill in label {}.".format(self.label)
 
+            elif self.action == "PICK COLOR":
+                text = "\nClick on a label to change the brush value to that value."
+
+            elif self.action == "DRAW BOX":
+                text = "\nDraw a bounding box around the area you want to threshold."
+
+            elif self.action == "CONVERSION BRUSH TARGET":
+                text = "\nClick on the label you want to draw OVER."
+
+            elif self.action == "CONVERSION BRUSH VALUE":
+                text = ("\nClick on the label you want to draw WITH,"
+                " or press N to set the brush to an unused label.")
+
+        elif self.kind == "DRAW":
+            text = ("\nUsing conversion brush to replace {} with {}."
+                "\nUse ESC to stop using the conversion brush.").format(self.conversion_brush_target,
+                self.conversion_brush_value)
+
+        return text
 
     @staticmethod
     def none():


### PR DESCRIPTION
Moderate refactor of desktop npz class (ZStackReview) to split functions into smaller pieces. 

Adds documentation (docstrings and comments) throughout class. Updates some minor behaviors (draw_line makes box around image, actions use the frame where they were activated instead of current_frame, add_cell and del_cell helpers added to some actions just in case, add ability to open files that don't contain annotations). Changes how some pieces are put together without changing behavior (screen_scale moved to on_resize, update "slices" info when modifying cell_info instead of on_draw). Removes active contour prediction because it was not very useful (and to free up a keybind).