### PR TITLE
Desktop/CalibanWindow, CalibanBrush classes

### DIFF
--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -313,6 +313,55 @@ class CalibanWindow:
                                  y_location=self.y, x_location=self.x)
             self.highlighted_cell_one = label
 
+    def mouse_press_selected_helper(self, label):
+        '''
+        Handles mouse presses when not in edit mode and when one label has already
+        been selected. Modifies self.mode to include info about both labels that have
+        been selected.
+
+        Uses:
+            label from click location (determined in on_mouse_press)
+            self.mode to store info about both selected labels
+            self.highlighted_cell_one and self.highlighted_cell_two to update
+                highlights appropriately; update cell_one because user could have
+                changed highlight with cycling after selecting first label
+                (note: this should change soon so that cycling the highlight deselects
+                whatever label is selected, as in browser caliban)
+        '''
+        if label != 0:
+            self.mode.update("MULTIPLE",
+                             label_1=self.mode.label,
+                             frame_1=self.mode.frame,
+                             y1_location = self.mode.y_location,
+                             x1_location = self.mode.x_location,
+                             label_2=label,
+                             frame_2=self.current_frame,
+                             y2_location = self.y,
+                             x2_location = self.x)
+            self.highlighted_cell_one = self.mode.label_1
+            self.highlighted_cell_two = label
+
+    def mouse_press_prompt_helper(self, label):
+        '''
+        Handles mouse presses when not in edit mode and in response to a
+        prompt (currently, hole fill is the only action with this pattern).
+        Only fills hole if user has clicked on an empty/background pixel (label is 0).
+        If appropriate pixel is clicked on, action_fill_hole is called before
+        resetting the hole_fill_seed and self.mode.
+
+        Uses:
+            self.mode.action to determine what response to mouse press should be
+            label from click location (determined in on_mouse_press) to check if
+                action should be carried out
+            self.hole_fill_seed to store start point for action_fill_hole
+            self.mode to clear action info once action has finished
+        '''
+        if self.mode.action == "FILL HOLE":
+            if label == 0:
+                self.hole_fill_seed = (self.y, self.x)
+                self.action_fill_hole()
+                self.mode.clear()
+
     def pick_color(self):
         '''
         Takes the label clicked on, sets self.brush.edit_val to that label, and then
@@ -1991,55 +2040,6 @@ class ZStackReview(CalibanWindow):
                 # start drawing bounding box for threshold prediction
                 elif self.mode.kind == "PROMPT" and self.mode.action == "DRAW BOX":
                     self.brush.set_box_corner(self.y, self.x)
-
-    def mouse_press_selected_helper(self, label):
-        '''
-        Handles mouse presses when not in edit mode and when one label has already
-        been selected. Modifies self.mode to include info about both labels that have
-        been selected.
-
-        Uses:
-            label from click location (determined in on_mouse_press)
-            self.mode to store info about both selected labels
-            self.highlighted_cell_one and self.highlighted_cell_two to update
-                highlights appropriately; update cell_one because user could have
-                changed highlight with cycling after selecting first label
-                (note: this should change soon so that cycling the highlight deselects
-                whatever label is selected, as in browser caliban)
-        '''
-        if label != 0:
-            self.mode.update("MULTIPLE",
-                             label_1=self.mode.label,
-                             frame_1=self.mode.frame,
-                             y1_location = self.mode.y_location,
-                             x1_location = self.mode.x_location,
-                             label_2=label,
-                             frame_2=self.current_frame,
-                             y2_location = self.y,
-                             x2_location = self.x)
-            self.highlighted_cell_one = self.mode.label_1
-            self.highlighted_cell_two = label
-
-    def mouse_press_prompt_helper(self, label):
-        '''
-        Handles mouse presses when not in edit mode and in response to a
-        prompt (currently, hole fill is the only action with this pattern).
-        Only fills hole if user has clicked on an empty/background pixel (label is 0).
-        If appropriate pixel is clicked on, action_fill_hole is called before
-        resetting the hole_fill_seed and self.mode.
-
-        Uses:
-            self.mode.action to determine what response to mouse press should be
-            label from click location (determined in on_mouse_press) to check if
-                action should be carried out
-            self.hole_fill_seed to store start point for action_fill_hole
-            self.mode to clear action info once action has finished
-        '''
-        if self.mode.action == "FILL HOLE":
-            if label == 0:
-                self.hole_fill_seed = (self.y, self.x)
-                self.action_fill_hole()
-                self.mode.clear()
 
     def handle_threshold(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -652,6 +652,26 @@ class CalibanWindow:
         # draw the label
         cell_info_label.draw()
 
+    def create_disp_image_text(self):
+        '''
+        '''
+        display_text = "Displayed image: "
+
+        if self.edit_mode:
+            if self.hide_annotations:
+                currently_viewing = "Raw"
+            else:
+                currently_viewing = "Overlay"
+        else:
+            if self.draw_raw:
+                currently_viewing = "Raw"
+            else:
+                currently_viewing = "Labels"
+
+        display_text += currently_viewing
+
+        return display_text
+
     def create_highlight_text(self):
         '''
         Generate text describing current highlighting status.
@@ -2605,26 +2625,6 @@ class ZStackReview(CalibanWindow):
         self.draw_cell_info_label()
 
         self.render_frame_info_helper()
-
-    def create_disp_image_text(self):
-        '''
-        '''
-        display_text = "Displayed image: "
-
-        if self.edit_mode:
-            if self.hide_annotations:
-                currently_viewing = "Raw"
-            else:
-                currently_viewing = "Overlay"
-        else:
-            if self.draw_raw:
-                currently_viewing = "Raw"
-            else:
-                currently_viewing = "Labels"
-
-        display_text += currently_viewing
-
-        return display_text
 
     def create_cmap_text(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1503,7 +1503,8 @@ class ZStackReview(CalibanWindow):
         # has effect of showing contours in brightness of image
         self.cmap_options = ['cubehelix', 'gist_yarg', 'gist_gray', 'magma', 'nipy_spectral', 'prism']
         # start on cubehelix cmap
-        self.current_cmap = 0
+        self.current_cmap_idx = 0
+        self.current_cmap = self.cmap_options[self.current_cmap_idx]
 
         self.brush = CalibanBrush(self.height, self.width)
 
@@ -2217,15 +2218,17 @@ class ZStackReview(CalibanWindow):
 
             if modifiers & key.MOD_SHIFT:
                 if symbol == key.UP:
-                    if self.current_cmap == len(self.cmap_options) - 1:
-                        self.current_cmap = 0
-                    elif self.current_cmap < len(self.cmap_options) -1:
-                        self.current_cmap += 1
+                    if self.current_cmap_idx == len(self.cmap_options) - 1:
+                        self.current_cmap_idx = 0
+                    elif self.current_cmap_idx < len(self.cmap_options) - 1:
+                        self.current_cmap_idx += 1
+                    self.current_cmap = self.cmap_options[self.current_cmap_idx]
                 if symbol == key.DOWN:
-                    if self.current_cmap == 0:
-                        self.current_cmap = len(self.cmap_options) - 1
-                    elif self.current_cmap > 0:
-                        self.current_cmap -= 1
+                    if self.current_cmap_idx == 0:
+                        self.current_cmap_idx = len(self.cmap_options) - 1
+                    elif self.current_cmap_idx > 0:
+                        self.current_cmap_idx -= 1
+                    self.current_cmap = self.cmap_options[self.current_cmap_idx]
 
     def label_mode_none_keypress_helper(self, symbol, modifiers):
         '''
@@ -2588,7 +2591,7 @@ class ZStackReview(CalibanWindow):
                 cmap = "gist_stern/gray"
         else:
             if self.draw_raw:
-                cmap = self.cmap_options[self.current_cmap]
+                cmap = self.current_cmap
             else:
                 cmap = "cubehelix"
 
@@ -2679,7 +2682,7 @@ class ZStackReview(CalibanWindow):
 
     def draw_raw_frame(self):
         raw_array = self.get_raw_current_frame()
-        adjusted_raw = self.apply_raw_image_adjustments(raw_array, cmap = self.cmap_options[self.current_cmap])
+        adjusted_raw = self.apply_raw_image_adjustments(raw_array, cmap = self.current_cmap)
         image = self.array_to_img(input_array = adjusted_raw,
             vmax = None,
             cmap = None,

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1952,10 +1952,10 @@ class ZStackReview(CalibanWindow):
             self.hole_fill_seed = None
             # reset self.mode (deselects labels, clears actions)
             self.mode.clear()
-            # reset conversion brush values
-            self.brush.clear_conv()
             # reset from thresholding
             self.brush.show = True
+            # reset conversion brush values
+            self.brush.clear_conv()
 
     def edit_mode_universal_keypress_helper(self, symbol, modifiers):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -631,6 +631,45 @@ class CalibanWindow:
         # set self.composite view to new composite image
         self.composite_view = img_masked
 
+    def draw_persistent_info(self):
+        '''
+        Display information about the frame currently being viewed.
+        Always displays information; highlight info is only info
+        conditionally displayed by this label. This info is displayed
+        at top of info column.
+        '''
+        if self.edit_mode:
+            edit_mode = "pixels"
+        else:
+            edit_mode = "labels"
+
+        if self.edit_mode or self.draw_raw:
+            filter_info = self.create_filter_text()
+        else:
+            filter_info = "\n\n\n"
+
+        display_filter_info = ("Current display settings:"
+            "\nColormap - {}").format(self.create_cmap_text())
+        display_filter_info += filter_info
+
+        # TODO: render label in a batch
+        # create pyglet label anchored to top of left side
+        frame_label = pyglet.text.Label("Currently viewing:\n"
+                                        + "{}".format(self.create_frame_text())
+                                        + "{}\n\n".format(self.create_disp_image_text())
+                                        + "{}\n".format(self.create_highlight_text())
+                                        + "{}\n\n".format(display_filter_info)
+                                        + "Edit mode: {}\n".format(edit_mode)
+                                        + self.create_brush_text(),
+                                        font_name="monospace",
+                                        anchor_x="left", anchor_y="top",
+                                        width=self.sidebar_width,
+                                        multiline=True,
+                                        x=5, y=self.window.height - 5,
+                                        color=[255]*4)
+        # draw the label
+        frame_label.draw()
+
     def draw_cell_info_label(self):
         '''
         When cursor is over a label, displays information about that label
@@ -1181,45 +1220,13 @@ class TrackReview(CalibanWindow):
         info["frames"] = frames
         return info
 
+    def create_frame_text(self):
+        frame_text = "Frame: {}\n".format(self.current_frame)
+        return frame_text
+
     def draw_label(self):
-
-        if self.edit_mode:
-            edit_mode = "on"
-            brush_size_display = "brush size: {}".format(self.brush.size)
-            edit_label_display = "editing label: {}".format(self.brush.edit_val)
-            if self.brush.erase:
-                erase_mode = "on"
-            else:
-                erase_mode = "off"
-            draw_or_erase = "eraser mode: {}".format(erase_mode)
-
-            edit_label = pyglet.text.Label('{}\n{}\n{}'.format(brush_size_display,
-                                                        edit_label_display,
-                                                        draw_or_erase),
-                                            font_name='monospace',
-                                            anchor_x='left', anchor_y='center',
-                                            width=self.sidebar_width,
-                                            multiline=True,
-                                            x=5, y=self.window.height//2,
-                                            color=[255]*4)
-            edit_label.draw()
-        else:
-            edit_mode = "off"
-
-        highlight_text = self.create_highlight_text()
-
-        frame_label = pyglet.text.Label("frame: {}".format(self.current_frame)
-                                    + "\nedit mode: {}".format(edit_mode)
-                                    + "\n{}".format(highlight_text),
-                                        font_name="monospace",
-                                        anchor_x="left", anchor_y="top",
-                                        width=self.sidebar_width,
-                                        multiline=True,
-                                        x=5, y=self.window.height - 5,
-                                        color=[255]*4)
-
+        self.draw_persistent_info()
         self.draw_cell_info_label()
-        frame_label.draw()
 
     def action_new_track(self):
         """
@@ -2636,56 +2643,20 @@ class ZStackReview(CalibanWindow):
     def get_label_info(self, label):
         return self.cell_info[self.feature][label]
 
+    def create_frame_text(self):
+        frame_text = ("Frame: {}\n".format(self.current_frame)
+                    + "Channel: {}\n".format(self.channel)
+                    + "Feature: {}\n".format(self.feature))
+        return frame_text
+
     def draw_label(self):
         '''
         Coordinates information display (text) on left side of screen.
         '''
         # TODO: only update labels when the content changes?
         # TODO: batch graphics?
+        self.draw_persistent_info()
         self.draw_cell_info_label()
-
-        self.render_frame_info_helper()
-
-    def render_frame_info_helper(self):
-        '''
-        Display information about the frame currently being viewed.
-        Always displays information; highlight info is only info
-        conditionally displayed by this label. This info is displayed
-        at top of info column.
-        '''
-        if self.edit_mode:
-            edit_mode = "pixels"
-        else:
-            edit_mode = "labels"
-
-        if self.edit_mode or self.draw_raw:
-            filter_info = self.create_filter_text()
-        else:
-            filter_info = "\n\n\n"
-
-        display_filter_info = ("Current display settings:"
-            "\nColormap - {}").format(self.create_cmap_text())
-        display_filter_info += filter_info
-
-        # TODO: render label in a batch
-        # create pyglet label anchored to top of left side
-        frame_label = pyglet.text.Label("Currently viewing:\n"
-                                        + "Frame: {}\n".format(self.current_frame)
-                                        + "Channel: {}\n".format(self.channel)
-                                        + "Feature: {}\n".format(self.feature)
-                                        + "{}\n\n".format(self.create_disp_image_text())
-                                        + "{}\n".format(self.create_highlight_text())
-                                        + "{}\n\n".format(display_filter_info)
-                                        + "Edit mode: {}\n".format(edit_mode)
-                                        + self.create_brush_text(),
-                                        font_name="monospace",
-                                        anchor_x="left", anchor_y="top",
-                                        width=self.sidebar_width,
-                                        multiline=True,
-                                        x=5, y=self.window.height - 5,
-                                        color=[255]*4)
-        # draw the label
-        frame_label.draw()
 
     def change_channel(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -297,6 +297,25 @@ class CalibanWindow:
                      left, top))
         )
 
+    def draw_ann_frame(self):
+        ann_array = self.get_ann_current_frame()
+
+        # annotations use cubehelix cmap with highlighting in red
+        cmap = plt.get_cmap("cubehelix")
+        cmap.set_bad('red')
+
+        # if highlighting on, mask highlighted values so they appear red
+        if self.highlight:
+            ann_array = self.apply_label_highlight(ann_array)
+
+        # create pyglet image
+        image = self.array_to_img(input_array = ann_array,
+                                                vmax = max(1, self.get_max_label() + self.adjustment),
+                                                cmap = cmap,
+                                                output = 'pyglet')
+
+        self.draw_pyglet_image(image)
+
     def draw_pyglet_image(self, image, opacity = 255):
         # TODO: add sprite to batch?
         pad = self.image_padding
@@ -1012,24 +1031,6 @@ class TrackReview(CalibanWindow):
                                          cmap = "cubehelix",
                                          output = 'pyglet')
 
-        self.draw_pyglet_image(image)
-
-    def draw_ann_frame(self):
-        ann_array = self.get_ann_current_frame()
-
-        # annotations use cubehelix cmap with highlighting in red
-        cmap = plt.get_cmap("cubehelix")
-        cmap.set_bad('red')
-
-        # if highlighting on, mask highlighted values so they appear red
-        if self.highlight:
-            ann_array = self.apply_label_highlight(ann_array)
-
-        # create pyglet image
-        image = self.array_to_img(input_array = ann_array,
-                                                vmax = self.get_max_label() + self.adjustment,
-                                                cmap = cmap,
-                                                output = 'pyglet')
         self.draw_pyglet_image(image)
 
     def draw_pixel_edit_frame(self):
@@ -2683,25 +2684,6 @@ class ZStackReview(CalibanWindow):
             vmax = None,
             cmap = None,
             output = 'pyglet')
-
-        self.draw_pyglet_image(image)
-
-    def draw_ann_frame(self):
-        ann_array = self.get_ann_current_frame()
-
-        # annotations use cubehelix cmap with highlighting in red
-        cmap = plt.get_cmap("cubehelix")
-        cmap.set_bad('red')
-
-        # if highlighting on, mask highlighted values so they appear red
-        if self.highlight:
-            ann_array = self.apply_label_highlight(ann_array)
-
-        # create pyglet image
-        image = self.array_to_img(input_array = ann_array,
-                                                vmax = max(1, self.get_max_label() + self.adjustment),
-                                                cmap = cmap,
-                                                output = 'pyglet')
 
         self.draw_pyglet_image(image)
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -740,7 +740,7 @@ class CalibanWindow:
                 value_text += "-"
                 erase_text += "-"
 
-            brush_info_text = "Current brush settings:\n\n{}\n{}\n{}".format(size_text,
+            brush_info_text = "\nCurrent brush settings:\n{}\n{}\n{}".format(size_text,
                 value_text, erase_text)
         else:
             brush_info_text = ""

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -118,6 +118,8 @@ class CalibanWindow:
         # show only raw image instead of composited image
         self.hide_annotations = False
 
+        self.overlay_cmap = 'gist_stern'
+
         # composite_view used to store RGB image (composite of raw and annotated) so it can be
         # accessed and updated as needed
         self.composite_view = np.zeros((1,self.height,self.width,3))
@@ -347,7 +349,7 @@ class CalibanWindow:
         # create pyglet image object so we can display brush location
         brush_img = self.array_to_img(input_array = self.brush.view,
                                                     vmax = self.get_max_label() + self.adjustment,
-                                                    cmap = 'gist_stern',
+                                                    cmap = self.overlay_cmap,
                                                     output = 'pyglet')
 
         # create pyglet image from only the adjusted raw, if hiding annotations
@@ -554,7 +556,7 @@ class CalibanWindow:
         # get RGB array of colorful annotation view
         ann_img = self.array_to_img(input_array = current_ann,
                                             vmax = self.get_max_label() + self.adjustment,
-                                            cmap = 'gist_stern',
+                                            cmap = self.overlay_cmap,
                                             output = 'array')
 
         # don't need alpha channel
@@ -2613,7 +2615,7 @@ class ZStackReview(CalibanWindow):
                 # TODO: replace with actual gray cmap name
                 cmap = "Gray"
             else:
-                cmap = "gist_stern/gray"
+                cmap = "{}/gray".format(self.overlay_cmap)
         else:
             if self.draw_raw:
                 cmap = self.current_cmap

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -890,7 +890,6 @@ class TrackReview(CalibanWindow):
         self.del_cell_info(del_label = old_label, frame = single_frame)
         self.add_cell_info(add_label = new_label, frame = single_frame)
 
-
     def action_watershed(self):
         # Pull the label that is being split and find a new valid label
         current_label = self.mode.label_1
@@ -931,7 +930,6 @@ class TrackReview(CalibanWindow):
 
         # current label doesn't change, but add the neccesary bookkeeping for the new track
         self.add_cell_info(add_label = new_label, frame = self.current_frame)
-
 
     def action_swap(self):
         def relabel(old_label, new_label):
@@ -983,7 +981,6 @@ class TrackReview(CalibanWindow):
 
         track_2["parent"] = label_1
         track_1["frame_div"] = frame_div
-
 
     def action_replace(self):
         """
@@ -1090,7 +1087,6 @@ class TrackReview(CalibanWindow):
                     pass
                 if track["parent"] == del_label:
                     track["parent"] = None
-
 
     def save(self):
         backup_file = self.filename + "_original.trk"

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -211,6 +211,36 @@ class CalibanWindow:
         if self.brush.show:
             self.brush.redraw_view()
 
+    def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
+        '''
+        Overwrite default pyglet window on_mouse_drag event.
+        Takes x, y, button, modifiers as params (there are what the
+        window sends to this event when it is triggered by mouse drag),
+        but button and modifiers are not used in this custom event. X and y
+        are used to update self.x and self.y (coordinates of mouse within the
+        image; also updated when mouse moves). Mouse drag behavior changes depending
+        on edit mode, mode.kind, and mode.action. Helper functions are used for the
+        different modes of behavior.
+
+        Uses:
+            self.update_mouse_position to update current self.x and self.y from
+                event x and y
+            self.edit_mode, self.mode.kind, self.mode.action, self.brush.show
+                to determine response to mouse drag
+
+        Note: self.brush.show is not a user-toggled option but is used to display
+            the correct preview (threshold box vs path of brush)
+        '''
+        # always update self.x and self.y when mouse has moved
+        self.update_mouse_position(x, y)
+
+        # mouse drag only has special behavior in pixel-editing mode
+        if self.edit_mode:
+            # drawing with brush (normal or conversion)
+            self.brush.add_to_view()
+            # modify annotation
+            self.handle_draw()
+
     def mouse_press_none_helper(self, modifiers, label):
         '''
         Handles mouse presses when not in edit mode and nothing is selected.
@@ -1202,15 +1232,6 @@ class TrackReview(CalibanWindow):
             elif self.mode.kind == "PROMPT" and self.mode.action == "PICK COLOR":
                 self.pick_color()
 
-    def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
-
-        self.update_mouse_position(x, y)
-
-        if self.edit_mode:
-            #show where brush has drawn this time
-            self.brush.add_to_view()
-            self.handle_draw()
-
     def on_mouse_release(self, x, y, buttons, modifiers):
         if self.edit_mode:
             if self.brush.show:
@@ -1987,37 +2008,6 @@ class ZStackReview(CalibanWindow):
                 self.hole_fill_seed = (self.y, self.x)
                 self.action_fill_hole()
                 self.mode.clear()
-
-    def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
-        '''
-        Overwrite default pyglet window on_mouse_drag event.
-        Takes x, y, button, modifiers as params (there are what the
-        window sends to this event when it is triggered by mouse drag),
-        but button and modifiers are not used in this custom event. X and y
-        are used to update self.x and self.y (coordinates of mouse within the
-        image; also updated when mouse moves). Mouse drag behavior changes depending
-        on edit mode, mode.kind, and mode.action. Helper functions are used for the
-        different modes of behavior.
-
-        Uses:
-            self.update_mouse_position to update current self.x and self.y from
-                event x and y
-            self.edit_mode, self.mode.kind, self.mode.action, self.brush.show
-                to determine response to mouse drag
-
-        Note: self.brush.show is not a user-toggled option but is used to display
-            the correct preview (threshold box vs path of brush)
-        '''
-        # always update self.x and self.y when mouse has moved
-        self.update_mouse_position(x, y)
-
-        # mouse drag only has special behavior in pixel-editing mode
-        if self.edit_mode:
-            # drawing with brush (normal or conversion)
-            self.brush.add_to_view()
-            if self.brush.show:
-                # modify annotation
-                self.handle_draw()
 
     def on_mouse_release(self, x, y, buttons, modifiers):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -349,6 +349,18 @@ class CalibanWindow:
 
         return img_masked
 
+    def create_label_info_text(self):
+        label = self.get_label()
+        if label != 0:
+            # generate text from cell_info and display_info (use slices instead of frames)
+            text = '\n'.join("{:11}{}".format(str(k)+': ', self.get_label_info(label)[k])
+                              for k in self.display_info)
+        else:
+            # display nothing if not hovering over a label
+            text = ''
+
+        return text
+
 class TrackReview(CalibanWindow):
     possible_keys = {"label", "daughters", "frames", "parent", "frame_div",
                      "capped"}
@@ -694,14 +706,7 @@ class TrackReview(CalibanWindow):
         return info
 
     def draw_label(self):
-        # always use segmented output for label, not raw
-        label = self.get_label()
-        if label != 0:
-            text = '\n'.join("{:10} {}".format(k+':', self.get_label_info(label)[k])
-                             for k in self.display_info)
-        else:
-            text = ''
-
+        text = self.create_label_info_text()
         text += self.mode.text
 
         info_label = pyglet.text.Label(text, font_name="monospace",
@@ -2337,16 +2342,8 @@ class ZStackReview(CalibanWindow):
         When cursor is over a label, displays information about that label
         at the bottom of the information column.
         '''
-        # value of annotation at current position of mouse
-        label = self.get_label()
 
-        if label != 0:
-            # generate text from cell_info and display_info (use slices instead of frames)
-            text = '\n'.join("{:10}{}".format(str(k)+':', self.get_label_info(label)[k])
-                              for k in self.display_info)
-        # display nothing if not hovering over a label
-        else:
-            text = ''
+        text = self.create_label_info_text()
 
         # add info from self.mode (eg, prompts or "selected", etc)
         text += self.mode.text

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1191,9 +1191,11 @@ class ZStackReview(CalibanWindow):
         self.max_intensity = self.max_intensity_dict[self.channel]
 
         # keeps track of information about adjustment of colormap for viewing annotation labels
-        self.adjustment = {}
+        self.adjustment_dict = {}
         for feature in range(self.feature_max):
-            self.adjustment[feature] = 0
+            self.adjustment_dict[feature] = 0
+        # adjustment for initial feature
+        self.adjustment = self.adjustment_dict[self.feature]
 
         # mouse position in coordinates of array being viewed as image, (0,0) is placeholder
         # will be updated on mouse motion
@@ -1706,7 +1708,7 @@ class ZStackReview(CalibanWindow):
         Uses:
             self.draw_raw to determine which image to adjust (and which adjustment to use)
             self.max_intensity_dict and self.channel to set or change the brightness of raw images
-            self.cell_ids, self.adjustment, self.feature to determine when to stop decreasing
+            self.cell_ids, self.adjustment_dict, self.feature to determine when to stop decreasing
                 self.adjustment (applied to annotations when drawing to determine range of colormap
                 applied to frame)
             self.edit_mode, self.hide_annotations to check if the composite image should be updated
@@ -1728,8 +1730,9 @@ class ZStackReview(CalibanWindow):
         # adjusting colormap range of annotations
         elif not self.draw_raw:
             # self.adjustment value for the current feature should never reduce possible colors to 0
-            if self.get_max_label() + (self.adjustment[self.feature] - 1 * scroll_y) > 0:
-                self.adjustment[self.feature] = self.adjustment[self.feature] - 1 * scroll_y
+            if self.get_max_label() + (self.adjustment_dict[self.feature] - 1 * scroll_y) > 0:
+                self.adjustment_dict[self.feature] = self.adjustment_dict[self.feature] - 1 * scroll_y
+            self.adjustment = self.adjustment_dict[self.feature]
 
         # color/brightness adjustments will change what the composited image looks like
         if self.edit_mode and not self.hide_annotations:
@@ -2544,7 +2547,7 @@ class ZStackReview(CalibanWindow):
 
         # create pyglet image
         image = self.array_to_img(input_array = ann_array,
-                                                vmax = max(1, self.get_max_label() + self.adjustment[self.feature]),
+                                                vmax = max(1, self.get_max_label() + self.adjustment),
                                                 cmap = cmap,
                                                 output = 'pyglet')
 
@@ -2561,7 +2564,7 @@ class ZStackReview(CalibanWindow):
         '''
         # create pyglet image object so we can display brush location
         brush_img = self.array_to_img(input_array = self.brush_view,
-                                                    vmax = self.get_max_label() + self.adjustment[self.feature],
+                                                    vmax = self.get_max_label() + self.adjustment,
                                                     cmap = 'gist_stern',
                                                     output = 'pyglet')
 
@@ -2638,6 +2641,14 @@ class ZStackReview(CalibanWindow):
         '''
         # in this case we only need to update self.max_intensity
         self.max_intensity = self.max_intensity_dict[self.channel]
+
+    def change_feature(self):
+        '''
+        Method that updates current attributes as needed based on which
+        feature is being viewed.
+        '''
+        # only need to update self.adjustment
+        self.adjustment = self.adjustment_dict[self.feature]
 
     def action_new_single_cell(self):
         """
@@ -3268,7 +3279,7 @@ class ZStackReview(CalibanWindow):
 
         # get RGB array of colorful annotation view
         ann_img = self.array_to_img(input_array = current_ann,
-                                            vmax = self.get_max_label() + self.adjustment[self.feature],
+                                            vmax = self.get_max_label() + self.adjustment,
                                             cmap = 'gist_stern',
                                             output = 'array')
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -700,6 +700,11 @@ class CalibanBrush:
 class TrackReview(CalibanWindow):
     possible_keys = {"label", "daughters", "frames", "parent", "frame_div",
                      "capped"}
+
+    replace_prompt = ("\nReplace {} with {}?"
+                     "\nSPACE = REPLACE IN ALL FRAMES"
+                     "\nESC = CANCEL")
+
     def __init__(self, filename, lineage, raw, tracked):
         self.filename = filename
         self.tracks = lineage
@@ -727,6 +732,7 @@ class TrackReview(CalibanWindow):
         self.x = 0
         self.y = 0
         self.mode = Mode.none()
+        self.mode.update_prompt_additions = self.custom_prompt
         self.adjustment = 0
         self.highlight = False
         self.highlighted_cell_one = -1
@@ -1002,6 +1008,12 @@ class TrackReview(CalibanWindow):
                 self.mode.clear()
                 self.highlighted_cell_one = -1
                 self.highlighted_cell_two = -1
+
+    def custom_prompt(self):
+        if self.mode.kind == "QUESTION":
+            if self.mode.action == "REPLACE":
+                self.mode.text = TrackReview.replace_prompt.format(self.mode.label_2,
+                    self.mode.label_1)
 
     def get_raw_current_frame(self):
         return self.raw[self.current_frame,:,:,0]

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -110,7 +110,7 @@ class CalibanWindow:
 
         # IMAGE ADJUSTMENT TOGGLES
         # invert grayscale light/dark of raw image
-        self.invert = True
+        self.invert = False
         # apply sobel filter (emphasizes edges) to raw image
         self.sobel_on = False
         # apply adaptive histogram equalization to raw image

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -631,6 +631,15 @@ class CalibanWindow:
         # set self.composite view to new composite image
         self.composite_view = img_masked
 
+    def draw_label(self):
+        '''
+        Coordinates information display (text) on left side of screen.
+        '''
+        # TODO: only update labels when the content changes?
+        # TODO: batch graphics?
+        self.draw_persistent_info()
+        self.draw_cell_info_label()
+
     def draw_persistent_info(self):
         '''
         Display information about the frame currently being viewed.
@@ -1223,10 +1232,6 @@ class TrackReview(CalibanWindow):
     def create_frame_text(self):
         frame_text = "Frame: {}\n".format(self.current_frame)
         return frame_text
-
-    def draw_label(self):
-        self.draw_persistent_info()
-        self.draw_cell_info_label()
 
     def action_new_track(self):
         """
@@ -2648,15 +2653,6 @@ class ZStackReview(CalibanWindow):
                     + "Channel: {}\n".format(self.channel)
                     + "Feature: {}\n".format(self.feature))
         return frame_text
-
-    def draw_label(self):
-        '''
-        Coordinates information display (text) on left side of screen.
-        '''
-        # TODO: only update labels when the content changes?
-        # TODO: batch graphics?
-        self.draw_persistent_info()
-        self.draw_cell_info_label()
 
     def change_channel(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -694,6 +694,26 @@ class CalibanWindow:
 
         return highlight_text
 
+    def create_cmap_text(self):
+        '''
+        Generate text describing the current colormap being used.
+        Added to info display on side of screen.
+        '''
+        cmap = ""
+        if self.edit_mode:
+            if self.hide_annotations:
+                # TODO: replace with actual gray cmap name
+                cmap = "Gray"
+            else:
+                cmap = "{}/gray".format(self.overlay_cmap)
+        else:
+            if self.draw_raw:
+                cmap = self.current_cmap
+            else:
+                cmap = "cubehelix"
+
+        return cmap
+
     def create_filter_text(self):
         '''
         '''
@@ -2625,26 +2645,6 @@ class ZStackReview(CalibanWindow):
         self.draw_cell_info_label()
 
         self.render_frame_info_helper()
-
-    def create_cmap_text(self):
-        '''
-        Generate text describing the current colormap being used.
-        Added to info display on side of screen.
-        '''
-        cmap = ""
-        if self.edit_mode:
-            if self.hide_annotations:
-                # TODO: replace with actual gray cmap name
-                cmap = "Gray"
-            else:
-                cmap = "{}/gray".format(self.overlay_cmap)
-        else:
-            if self.draw_raw:
-                cmap = self.current_cmap
-            else:
-                cmap = "cubehelix"
-
-        return cmap
 
     def render_frame_info_helper(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -349,6 +349,28 @@ class CalibanWindow:
 
         return img_masked
 
+    def create_highlight_text(self):
+        '''
+        Generate text describing current highlighting status.
+        Added to info on side of screen.
+        '''
+        if self.edit_mode:
+            highlight_text = "Highlighting: -\nHighlighted cell(s): None\n"
+        else:
+            highlight_text = "Highlighting: {}\n".format(on_or_off(self.highlight))
+            if self.highlight:
+                if self.highlighted_cell_two != -1:
+                    labels = "{}, {}".format(self.highlighted_cell_one, self.highlighted_cell_two)
+                elif self.highlighted_cell_one != -1:
+                    labels = "{}".format(self.highlighted_cell_one)
+                else:
+                    labels = "None"
+            else:
+                labels = "None"
+            highlight_text += "Highlighted cell(s): {}\n".format(labels)
+
+        return highlight_text
+
     def create_label_info_text(self):
         label = self.get_label()
         if label != 0:
@@ -737,22 +759,10 @@ class TrackReview(CalibanWindow):
                                             x=5, y=self.window.height//2,
                                             color=[255]*4)
             edit_label.draw()
-
-
-            highlight_text = ""
-
         else:
             edit_mode = "off"
-            if self.highlight:
-                if self.highlighted_cell_two != -1:
-                    highlight_text = "highlight: on\nhighlighted cell 1: {}\nhighlighted cell 2: {}".format(self.highlighted_cell_one, self.highlighted_cell_two)
-                elif self.highlighted_cell_one != -1:
-                    highlight_text = "highlight: on\nhighlighted cell: {}".format(self.highlighted_cell_one)
-                else:
-                    highlight_text = "highlight: on"
-            else:
-                highlight_text = "highlight: off"
 
+        highlight_text = self.create_highlight_text()
 
         frame_label = pyglet.text.Label("frame: {}".format(self.current_frame)
                                     + "\nedit mode: {}".format(edit_mode)
@@ -2409,28 +2419,6 @@ class ZStackReview(CalibanWindow):
         display_text += currently_viewing
 
         return display_text
-
-    def create_highlight_text(self):
-        '''
-        Generate text describing current highlighting status.
-        Added to info on side of screen.
-        '''
-        if self.edit_mode:
-            highlight_text = "Highlighting: -\nHighlighted cell(s): None\n"
-        else:
-            highlight_text = "Highlighting: {}\n".format(on_or_off(self.highlight))
-            if self.highlight:
-                if self.highlighted_cell_two != -1:
-                    labels = "{}, {}".format(self.highlighted_cell_one, self.highlighted_cell_two)
-                elif self.highlighted_cell_one != -1:
-                    labels = "{}".format(self.highlighted_cell_one)
-                else:
-                    labels = "None"
-            else:
-                labels = "None"
-            highlight_text += "Highlighted cell(s): {}\n".format(labels)
-
-        return highlight_text
 
     def create_cmap_text(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -103,6 +103,21 @@ class CalibanWindow:
         # start with cursor visible, but this can be toggled
         self.mouse_visible = True
 
+        # start in label-editing mode
+        self.edit_mode = False
+        # start with display showing annotations
+        self.draw_raw = False
+
+        # IMAGE ADJUSTMENT TOGGLES
+        # invert grayscale light/dark of raw image
+        self.invert = True
+        # apply sobel filter (emphasizes edges) to raw image
+        self.sobel_on = False
+        # apply adaptive histogram equalization to raw image
+        self.adapthist_on = False
+        # show only raw image instead of composited image
+        self.hide_annotations = False
+
     def on_resize(self, width, height):
         '''
         Event handler for when pyglet window changes size. Note: this
@@ -361,7 +376,6 @@ class TrackReview(CalibanWindow):
         super().__init__()
 
         self.current_frame = 0
-        self.draw_raw = False
         self.max_intensity = None
         self.x = 0
         self.y = 0
@@ -373,7 +387,6 @@ class TrackReview(CalibanWindow):
 
         self.hole_fill_seed = None
 
-        self.edit_mode = False
         self.edit_value = 1
         self.brush_size = 1
         self.erase = False
@@ -1169,8 +1182,7 @@ class ZStackReview(CalibanWindow):
 
         # open file to first frame of annotation stack
         self.current_frame = 0
-        # start with display showing annotations
-        self.draw_raw = False
+
         # keeps track of information about brightness of each channel in raw images
         self.max_intensity_dict = {}
         for channel in range(self.channel_max):
@@ -1207,8 +1219,6 @@ class ZStackReview(CalibanWindow):
         # start on cubehelix cmap
         self.current_cmap = 0
 
-        # start in label-editing mode
-        self.edit_mode = False
         # set intial pixel-editing mode tool values
         self.edit_value = 1
         self.brush_size = 1
@@ -1222,15 +1232,6 @@ class ZStackReview(CalibanWindow):
         self.show_brush = True
         # stores starting point of thresholding bounding box
         self.predict_seed = None
-        # display options for pixel-editing mode
-        # invert grayscale light/dark of raw image
-        self.invert = True
-        # apply sobel filter (emphasizes edges) to raw image
-        self.sobel_on = False
-        # apply adaptive histogram equalization to raw image
-        self.adapthist_on = False
-        # show only raw image instead of composited image
-        self.hide_annotations = False
 
         # values for conversion brush tool
         self.conversion_brush_target = -1

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1708,43 +1708,45 @@ class TrackReview(CalibanWindow):
         '''
         helper function for actions that add a cell to the trk
         '''
-        #if cell already exists elsewhere in trk:
-        try:
-            old_frames = self.tracks[add_label]['frames']
-            updated_frames = np.append(old_frames, frame)
-            updated_frames = np.unique(updated_frames).tolist()
-            self.tracks[add_label].update({'frames': updated_frames})
-        #cell does not exist anywhere in trk:
-        except KeyError:
-            self.tracks.update({add_label: {}})
-            self.tracks[add_label].update({'label': int(add_label)})
-            self.tracks[add_label].update({'frames': [frame]})
-            self.tracks[add_label].update({'daughters': []})
-            self.tracks[add_label].update({'frame_div': None})
-            self.tracks[add_label].update({'parent': None})
-            self.tracks[add_label].update({'capped': False})
+        if add_label != 0:
+            #if cell already exists elsewhere in trk:
+            try:
+                old_frames = self.tracks[add_label]['frames']
+                updated_frames = np.append(old_frames, frame)
+                updated_frames = np.unique(updated_frames).tolist()
+                self.tracks[add_label].update({'frames': updated_frames})
+            #cell does not exist anywhere in trk:
+            except KeyError:
+                self.tracks.update({add_label: {}})
+                self.tracks[add_label].update({'label': int(add_label)})
+                self.tracks[add_label].update({'frames': [frame]})
+                self.tracks[add_label].update({'daughters': []})
+                self.tracks[add_label].update({'frame_div': None})
+                self.tracks[add_label].update({'parent': None})
+                self.tracks[add_label].update({'capped': False})
 
     def del_cell_info(self, del_label, frame):
         '''
         helper function for actions that remove a cell from the trk
         '''
-        #remove cell from frame
-        old_frames = self.tracks[del_label]['frames']
-        updated_frames = np.delete(old_frames, np.where(old_frames == np.int64(frame))).tolist()
-        self.tracks[del_label].update({'frames': updated_frames})
+        if del_label != 0:
+            #remove cell from frame
+            old_frames = self.tracks[del_label]['frames']
+            updated_frames = np.delete(old_frames, np.where(old_frames == np.int64(frame))).tolist()
+            self.tracks[del_label].update({'frames': updated_frames})
 
-        #if that was the last frame, delete the entry for that cell
-        if self.tracks[del_label]['frames'] == []:
-            del self.tracks[del_label]
+            #if that was the last frame, delete the entry for that cell
+            if self.tracks[del_label]['frames'] == []:
+                del self.tracks[del_label]
 
-            # If deleting lineage data, remove parent/daughter entries
-            for _, track in self.tracks.items():
-                try:
-                    track["daughters"].remove(del_label)
-                except ValueError:
-                    pass
-                if track["parent"] == del_label:
-                    track["parent"] = None
+                # If deleting lineage data, remove parent/daughter entries
+                for _, track in self.tracks.items():
+                    try:
+                        track["daughters"].remove(del_label)
+                    except ValueError:
+                        pass
+                    if track["parent"] == del_label:
+                        track["parent"] = None
 
     def save(self):
         backup_file = self.filename + "_original.trk"

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1051,19 +1051,13 @@ class TrackReview(CalibanWindow):
 
         elif self.edit_mode:
             if self.mode.kind is None:
-                annotated = self.tracked[self.current_frame,:,:,0]
+                annotated = self.get_ann_current_frame()
 
-                in_original = np.any(np.isin(annotated, self.brush.edit_val))
+                in_original = np.any(np.isin(annotated, self.brush.draw_value))
 
-                #do not overwrite or erase labels other than the one you're editing
-                if not self.brush.erase:
-                    annotated_draw = np.where(annotated==0, self.brush.edit_val, annotated)
-                    annotated[self.brush.area] = annotated_draw[self.brush.area]
-                else:
-                    annotated_erase = np.where(annotated==self.brush.edit_val, 0, annotated)
-                    annotated[self.brush.area] = annotated_erase[self.brush.area]
+                annotated = self.brush.draw(annotated)
 
-                in_modified = np.any(np.isin(annotated, self.brush.edit_val))
+                in_modified = np.any(np.isin(annotated, self.brush.draw_value))
 
                 #cell deletion
                 if in_original and not in_modified:
@@ -1083,22 +1077,16 @@ class TrackReview(CalibanWindow):
         self.update_mouse_position(x, y)
 
         if self.edit_mode:
-            annotated = self.tracked[self.current_frame,:,:,0]
-
             #show where brush has drawn this time
             self.brush.add_to_view()
 
-            in_original = np.any(np.isin(annotated, self.brush.edit_val))
+            annotated = self.get_ann_current_frame()
 
-            #do not overwrite or erase labels other than the one you're editing
-            if not self.brush.erase:
-                annotated_draw = np.where(annotated==0, self.brush.edit_val, annotated)
-                annotated[self.brush.area] = annotated_draw[self.brush.area]
-            else:
-                annotated_erase = np.where(annotated==self.brush.edit_val, 0, annotated)
-                annotated[self.brush.area] = annotated_erase[self.brush.area]
+            in_original = np.any(np.isin(annotated, self.brush.draw_value))
 
-            in_modified = np.any(np.isin(annotated, self.brush.edit_val))
+            annotated = self.brush.draw(annotated)
+
+            in_modified = np.any(np.isin(annotated, self.brush.draw_value))
 
             #cell deletion
             if in_original and not in_modified:

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -2342,8 +2342,6 @@ class ZStackReview(CalibanWindow):
         # TODO: batch graphics?
         self.render_cell_label_info_helper()
 
-        self.render_edit_mode_info_helper()
-
         self.render_frame_info_helper()
 
     def render_cell_label_info_helper(self):
@@ -2367,28 +2365,6 @@ class ZStackReview(CalibanWindow):
 
         # draw the label
         cell_info_label.draw()
-
-    def render_edit_mode_info_helper(self):
-        '''
-        Display information about pixel-editing mode (if in that mode).
-        Pixel-editing information such as brush attributes displayed in
-        center of information column.
-        '''
-        # TODO: display info about image settings (eg, which filters are turned on)
-
-        # only display while in pixel-editing mode
-        if self.edit_mode:
-            # TODO: render label in a batch
-            # create pyglet label anchored to middle of left side
-            edit_label = pyglet.text.Label(self.create_brush_text(),
-                                            font_name='monospace',
-                                            anchor_x='left', anchor_y='center',
-                                            width=self.sidebar_width,
-                                            multiline=True,
-                                            x=5, y=self.window.height//2,
-                                            color=[255]*4)
-            # draw the label
-            edit_label.draw()
 
     def create_disp_image_text(self):
         '''
@@ -2440,22 +2416,26 @@ class ZStackReview(CalibanWindow):
         return filter_text
 
     def create_brush_text(self):
-        size_text = "Brush size: "
-        if self.show_brush:
-            size_text += str(self.brush_size)
-        else:
-            size_text += "-"
+        if self.edit_mode:
+            size_text = "Brush size: "
+            if self.show_brush:
+                size_text += str(self.brush_size)
+            else:
+                size_text += "-"
 
-        value_text = "Editing label: "
-        erase_text = "Eraser: "
-        if self.mode.kind is None:
-            value_text += str(self.edit_value)
-            erase_text += on_or_off(self.erase)
-        else:
-            value_text += "-"
-            erase_text += "-"
+            value_text = "Editing label: "
+            erase_text = "Eraser: "
+            if self.mode.kind is None:
+                value_text += str(self.edit_value)
+                erase_text += on_or_off(self.erase)
+            else:
+                value_text += "-"
+                erase_text += "-"
 
-        brush_info_text = "{}\n{}\n{}".format(size_text, value_text, erase_text)
+            brush_info_text = "Current brush settings:\n\n{}\n{}\n{}".format(size_text,
+                value_text, erase_text)
+        else:
+            brush_info_text = ""
 
         return brush_info_text
 
@@ -2489,7 +2469,8 @@ class ZStackReview(CalibanWindow):
                                         + "{}\n\n".format(self.create_disp_image_text())
                                         + "{}\n".format(self.create_highlight_text())
                                         + "{}\n\n".format(display_filter_info)
-                                        + "Edit mode: {}\n".format(edit_mode),
+                                        + "Edit mode: {}\n".format(edit_mode)
+                                        + self.create_brush_text(),
                                         font_name="monospace",
                                         anchor_x="left", anchor_y="top",
                                         width=self.sidebar_width,

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -297,6 +297,16 @@ class CalibanWindow:
                      left, top))
         )
 
+    def draw_raw_frame(self):
+        raw_array = self.get_raw_current_frame()
+        adjusted_raw = self.apply_raw_image_adjustments(raw_array, cmap = self.current_cmap)
+        image = self.array_to_img(input_array = adjusted_raw,
+            vmax = None,
+            cmap = None,
+            output = 'pyglet')
+
+        self.draw_pyglet_image(image)
+
     def draw_ann_frame(self):
         ann_array = self.get_ann_current_frame()
 
@@ -669,6 +679,8 @@ class TrackReview(CalibanWindow):
         self.highlighted_cell_one = -1
         self.highlighted_cell_two = -1
 
+        self.current_cmap = 'cubehelix'
+
         self.hole_fill_seed = None
 
         self.brush = CalibanBrush(self.height, self.width)
@@ -1023,15 +1035,6 @@ class TrackReview(CalibanWindow):
         gl.glTexParameteri(gl.GL_TEXTURE_2D,
                            gl.GL_TEXTURE_MAG_FILTER,
                            gl.GL_NEAREST)
-
-    def draw_raw_frame(self):
-        raw_array = self.get_raw_current_frame()
-        image = self.array_to_img(input_array = raw_array,
-                                         vmax = self.max_intensity,
-                                         cmap = "cubehelix",
-                                         output = 'pyglet')
-
-        self.draw_pyglet_image(image)
 
     def draw_pixel_edit_frame(self):
         # create pyglet image object so we can display brush location
@@ -2679,16 +2682,6 @@ class ZStackReview(CalibanWindow):
 
         elif self.edit_mode:
             self.draw_edit_mode_frame()
-
-    def draw_raw_frame(self):
-        raw_array = self.get_raw_current_frame()
-        adjusted_raw = self.apply_raw_image_adjustments(raw_array, cmap = self.current_cmap)
-        image = self.array_to_img(input_array = adjusted_raw,
-            vmax = None,
-            cmap = None,
-            output = 'pyglet')
-
-        self.draw_pyglet_image(image)
 
     def draw_edit_mode_frame(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -188,6 +188,27 @@ class CalibanWindow:
             self.x, self.y = x, y
             self.brush.update_center(y, x)
 
+    def on_mouse_motion(self, x, y, dx, dy):
+        '''
+        Overwrite default pyglet window on_mouse_motion event.
+        Takes x, y, dx, dy as params (these are what the window sends
+        to this event when it is triggered by mouse motion), but dx and dy
+        are not used in this custom event. X and y are used to update self.x
+        and self.y (coordinates of mouse within the image; also updated during
+        mouse drag). Updates brush preview (pixel-editing mode) when appropriate.
+        Uses:
+            self.update_mouse_position to update current self.x and self.y from
+                event x and y (also updates brush location)
+            self.brush method redraw_view to clear and redraw the brush preview
+
+        Note: self.brush.show is not a user-toggled option but is used to display
+            the correct preview (threshold box vs path of brush)
+        '''
+        # always update self.x and self.y when mouse has moved
+        self.update_mouse_position(x, y)
+        if self.brush.show:
+            self.brush.redraw_view()
+
     def on_draw(self):
         '''
         Event handler for pyglet window, redraws all content of screen after
@@ -748,15 +769,6 @@ class TrackReview(CalibanWindow):
         else:
             if self.get_max_label() + (self.adjustment - 1 * scroll_y) > 0:
                 self.adjustment = self.adjustment - 1 * scroll_y
-
-    def on_mouse_motion(self, x, y, dx, dy):
-
-        self.update_mouse_position(x, y)
-
-        if self.edit_mode:
-            #display brush size
-            self.brush.clear_view()
-            self.brush.view[self.brush.area] = self.brush.edit_val
 
     def on_key_press(self, symbol, modifiers):
         # Set scroll speed (through sequential frames) with offset
@@ -1780,30 +1792,6 @@ class ZStackReview(CalibanWindow):
         # would need to add back if adding a "check if image modified" step like browser caliban has
 
         # self.annotated[self.current_frame,:,:,self.feature] = annotated
-
-    def on_mouse_motion(self, x, y, dx, dy):
-        '''
-        Overwrite default pyglet window on_mouse_motion event.
-        Takes x, y, dx, dy as params (these are what the window sends
-        to this event when it is triggered by mouse motion), but dx and dy
-        are not used in this custom event. X and y are used to update self.x
-        and self.y (coordinates of mouse within the image; also updated during
-        mouse drag). Updates brush preview (pixel-editing mode) when appropriate.
-        Uses:
-            self.update_mouse_position to update current self.x and self.y from
-                event x and y
-            self.edit_mode, self.mode.kind, self.brush.show to determine when to display
-                brush preview
-            self.brush.view, self.y, self.x, self.brush.size, self.height, self.width,
-                self.brush.conv_val, self.brush.edit_val to create brush preview
-
-        Note: self.brush.show is not a user-toggled option but is used to display
-            the correct preview (threshold box vs path of brush)
-        '''
-        # always update self.x and self.y when mouse has moved
-        self.update_mouse_position(x, y)
-        if self.brush.show:
-            self.brush.redraw_view()
 
     def on_mouse_scroll(self, x, y, scroll_x, scroll_y):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -453,6 +453,15 @@ class CalibanWindow:
 
         return highlight_text
 
+    def create_filter_text(self):
+        '''
+        '''
+        filter_text = ("\nSobel filter - {}".format(on_or_off(self.sobel_on))
+                    + "\nColor inversion - {}".format(on_or_off(self.invert))
+                    + "\nHistogram equalization - {}".format(on_or_off(self.adapthist_on)))
+
+        return filter_text
+
     def create_label_info_text(self):
         label = self.get_label()
         if label != 0:
@@ -2491,15 +2500,6 @@ class ZStackReview(CalibanWindow):
                 cmap = "cubehelix"
 
         return cmap
-
-    def create_filter_text(self):
-        '''
-        '''
-        filter_text = ("\nSobel filter - {}".format(on_or_off(self.sobel_on))
-                    + "\nColor inversion - {}".format(on_or_off(self.invert))
-                    + "\nHistogram equalization - {}".format(on_or_off(self.adapthist_on)))
-
-        return filter_text
 
     def create_brush_text(self):
         if self.edit_mode:

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -209,6 +209,40 @@ class CalibanWindow:
         if self.brush.show:
             self.brush.redraw_view()
 
+    def mouse_press_none_helper(self, modifiers, label):
+        '''
+        Handles mouse presses when not in edit mode and nothing is selected.
+        With modifiers (keys held down), can trigger ctrl-click to flood label,
+        shift-click to trim pixels, or normal click to select label.
+
+        Uses:
+            modifiers from mouse press event to determine if special click
+            label from click location (determined in on_mouse_press)
+            self.y and self.x to determine self.hole_fill_seed (special click functions)
+                or to add to self.mode.info as y_location and x_location
+            self.mode to prompt special click confirmation or to select label
+            self.highlighted_cell_one to update highlight info with label
+        '''
+        if label != 0:
+            if modifiers & key.MOD_CTRL:
+                self.hole_fill_seed = (self.y, self.x)
+                self.mode.update("QUESTION",
+                                 action = "FLOOD CELL",
+                                 label = label,
+                                 frame = self.current_frame)
+            elif modifiers & key.MOD_SHIFT:
+                self.hole_fill_seed = (self.y, self.x)
+                self.mode.update("QUESTION",
+                                 action = "TRIM PIXELS",
+                                 label = label,
+                                 frame = self.current_frame)
+            else:
+                self.mode.update("SELECTED",
+                                 label=label,
+                                 frame=self.current_frame,
+                                 y_location=self.y, x_location=self.x)
+            self.highlighted_cell_one = label
+
     def on_draw(self):
         '''
         Event handler for pyglet window, redraws all content of screen after
@@ -635,12 +669,7 @@ class TrackReview(CalibanWindow):
             label = self.get_label()
             if self.mode.kind is None:
                 if label != 0:
-                    self.mode.update("SELECTED",
-                                     label=label,
-                                     frame=self.current_frame,
-                                     y_location=self.y, x_location=self.x)
-                    self.highlighted_cell_one = label
-                    self.highlighted_cell_two = -1
+                    self.mouse_press_none_helper(modifiers, label)
             elif self.mode.kind == "SELECTED":
                 if label != 0:
                     self.highlighted_cell_one = self.mode.label
@@ -1547,40 +1576,6 @@ class ZStackReview(CalibanWindow):
                 # start drawing bounding box for threshold prediction
                 elif self.mode.kind == "PROMPT" and self.mode.action == "DRAW BOX":
                     self.predict_seed = (self.y, self.x)
-
-    def mouse_press_none_helper(self, modifiers, label):
-        '''
-        Handles mouse presses when not in edit mode and nothing is selected.
-        With modifiers (keys held down), can trigger ctrl-click to flood label,
-        shift-click to trim pixels, or normal click to select label.
-
-        Uses:
-            modifiers from mouse press event to determine if special click
-            label from click location (determined in on_mouse_press)
-            self.y and self.x to determine self.hole_fill_seed (special click functions)
-                or to add to self.mode.info as y_location and x_location
-            self.mode to prompt special click confirmation or to select label
-            self.highlighted_cell_one to update highlight info with label
-        '''
-        if label != 0:
-            if modifiers & key.MOD_CTRL:
-                self.hole_fill_seed = (self.y, self.x)
-                self.mode.update("QUESTION",
-                                 action = "FLOOD CELL",
-                                 label = label,
-                                 frame = self.current_frame)
-            elif modifiers & key.MOD_SHIFT:
-                self.hole_fill_seed = (self.y, self.x)
-                self.mode.update("QUESTION",
-                                 action = "TRIM PIXELS",
-                                 label = label,
-                                 frame = self.current_frame)
-            else:
-                self.mode.update("SELECTED",
-                                 label=label,
-                                 frame=self.current_frame,
-                                 y_location=self.y, x_location=self.x)
-            self.highlighted_cell_one = label
 
     def mouse_press_selected_helper(self, label):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -720,6 +720,9 @@ class TrackReview(CalibanWindow):
     def get_max_label(self):
         return max(self.tracks)
 
+    def get_new_label(self):
+        return (self.get_max_label() + 1)
+
     def get_label_info(self, label):
         info = self.tracks[label].copy()
         frames = list(map(list, consecutive(info["frames"])))
@@ -861,7 +864,7 @@ class TrackReview(CalibanWindow):
         Replacing label
         """
         old_label, start_frame = self.mode.label, self.mode.frame
-        new_label = self.get_max_label() + 1
+        new_label = self.get_new_label()
 
         if start_frame == 0:
             raise ValueError("new_track cannot be called on the first frame")
@@ -895,7 +898,7 @@ class TrackReview(CalibanWindow):
         Create new label in just one frame
         """
         old_label, single_frame = self.mode.label, self.mode.frame
-        new_label = self.get_max_label() + 1
+        new_label = self.get_new_label()
 
         # replace frame labels
         frame = self.tracked[single_frame]
@@ -908,7 +911,7 @@ class TrackReview(CalibanWindow):
     def action_watershed(self):
         # Pull the label that is being split and find a new valid label
         current_label = self.mode.label_1
-        new_label = self.get_max_label() + 1
+        new_label = self.get_new_label()
 
         # Locally store the frames to work on
         img_raw = self.raw[self.current_frame]

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -2122,6 +2122,26 @@ class ZStackReview(CalibanWindow):
 
         # cycle through colormaps, but only while viewing raw
         if self.draw_raw:
+
+            # INVERT RAW IMAGE LIGHT/DARK
+            if symbol == key.I:
+                self.invert = not self.invert
+                # if you invert the image while you're viewing composite, update composite
+                if not self.hide_annotations:
+                    self.helper_update_composite()
+
+            # TOGGLE SOBEL FILTER
+            if symbol == key.K:
+                self.sobel_on = not self.sobel_on
+                if not self.hide_annotations:
+                    self.helper_update_composite()
+
+            # TOGGLE ADAPTIVE HISTOGRAM EQUALIZATION
+            if symbol == key.J:
+                self.adapthist_on = not self.adapthist_on
+                if not self.hide_annotations:
+                    self.helper_update_composite()
+
             if modifiers & key.MOD_SHIFT:
                 if symbol == key.UP:
                     if self.current_cmap == len(self.cmap_options) - 1:
@@ -2534,12 +2554,12 @@ class ZStackReview(CalibanWindow):
         '''
         if self.edit_mode:
             edit_mode = "pixels"
-            filter_info = self.create_filter_text()
-
-        # label-editing mode
         else:
             edit_mode = "labels"
-            # can't currently apply filters to raw image
+
+        if self.edit_mode or self.draw_raw:
+            filter_info = self.create_filter_text()
+        else:
             filter_info = "\n\n\n"
 
         display_filter_info = ("Current display settings:"
@@ -2586,10 +2606,11 @@ class ZStackReview(CalibanWindow):
 
     def draw_raw_frame(self):
         raw_array = self.get_raw_current_frame()
-        image = self.array_to_img(input_array = raw_array,
-                                         vmax = self.max_intensity,
-                                         cmap = self.cmap_options[self.current_cmap],
-                                         output = 'pyglet')
+        adjusted_raw = self.apply_raw_image_adjustments(raw_array, cmap = self.cmap_options[self.current_cmap])
+        image = self.array_to_img(input_array = adjusted_raw,
+            vmax = None,
+            cmap = None,
+            output = 'pyglet')
 
         self.draw_pyglet_image(image)
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -150,12 +150,12 @@ class CalibanWindow:
                 (self.x and self.y will not update if mouse has moved outside of image)
         '''
         # convert event x to image x by accounting for sidebar width, then scale
-        x -= self.sidebar_width
+        x -= (self.sidebar_width + self.image_padding)
         x //= self.scale_factor
 
         # convert event y to image y by rescaling and changing coordinates:
         # pyglet y has increasing y at the top of the screen, opposite convention of array indices
-        y = self.height - (y // self.scale_factor)
+        y = self.height - ((y - self.image_padding)// self.scale_factor)
 
         # check that mouse cursor is within bounds of image before updating
         if 0 <= x < self.width and 0 <= y < self.height:
@@ -196,21 +196,31 @@ class CalibanWindow:
         frame_width = self.scale_factor * self.width
         frame_height = self.scale_factor * self.height
 
+        pad = self.image_padding
+
+        top = frame_height + pad
+        bottom = pad
+        left = self.sidebar_width + pad
+        right = self.sidebar_width + frame_width + pad
+
+        # interior part of border
         pyglet.graphics.draw(8, pyglet.gl.GL_LINES,
-            ("v2f", (self.sidebar_width, frame_height,
-                     self.sidebar_width, 0,
-                     self.sidebar_width, 0,
-                     self.sidebar_width + frame_width, 0,
-                     self.sidebar_width + frame_width, 0,
-                     self.sidebar_width + frame_width, frame_height,
-                     self.sidebar_width + frame_width, frame_height,
-                     self.sidebar_width, frame_height))
+            ("v2f", (left, top,
+                     left, bottom-1,
+                     left, bottom-1,
+                     right+1, bottom-1,
+                     right+1, bottom-1,
+                     right+1, top,
+                     right+1, top,
+                     left, top))
         )
 
     def draw_pyglet_image(self, image, opacity = 255):
         # TODO: add sprite to batch?
+        pad = self.image_padding
+
         # create pyglet sprite, bottom left corner of image anchored with some offset
-        sprite = pyglet.sprite.Sprite(image, x=self.sidebar_width, y=0)
+        sprite = pyglet.sprite.Sprite(image, x=self.sidebar_width + pad, y=pad)
 
         # scale x and y dimensions of sprite
         sprite.update(scale_x=self.scale_factor,

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -51,6 +51,10 @@ from imageio import imread, imwrite
 
 gl.glEnable(gl.GL_TEXTURE_2D)
 
+platform = pyglet.window.get_platform()
+display = platform.get_default_display()
+USER_SCREEN = display.get_default_screen()
+
 class CalibanWindow:
     # blank area to the left of displayed image where text info is displayed
     sidebar_width = 300
@@ -60,6 +64,9 @@ class CalibanWindow:
 
     # window is always a resizable pyglet window
     window = pyglet.window.Window(resizable=True)
+
+    # set maximum size based on user's screen
+    window.set_maximum_size(width = USER_SCREEN.width - 40, height = USER_SCREEN.height - 40)
 
     # use crosshair cursor instead of usual cursor
     cursor = window.get_system_mouse_cursor(window.CURSOR_CROSSHAIR)

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -1783,11 +1783,11 @@ class ZStackReview(CalibanWindow):
         elif self.edit_mode:
             # draw using brush
             if self.mode.kind is None:
-                self.handle_draw_helper()
+                self.handle_draw()
             elif self.mode.kind is not None:
                 # conversion brush
                 if self.mode.kind == "DRAW":
-                    self.handle_draw_helper()
+                    self.handle_draw()
 
                 # color pick tool
                 elif self.mode.kind == "PROMPT" and self.mode.action == "PICK COLOR":
@@ -1882,7 +1882,7 @@ class ZStackReview(CalibanWindow):
                 # # update brush_view if self.mode.kind is DRAW or None, but not PROMPT
                 self.brush.add_to_view()
                 # modify annotation
-                self.handle_draw_helper()
+                self.handle_draw()
 
             # dragging the bounding box for threshold prediction
             elif not self.brush.show and self.mode.action == "DRAW BOX":
@@ -1965,7 +1965,7 @@ class ZStackReview(CalibanWindow):
         self.brush.enable_drawing()
         self.mode.clear()
 
-    def handle_draw_helper(self):
+    def handle_draw(self):
         '''
         Carries out brush drawing on annotation in edit mode. Handles both conversion brush
         and normal drawing or erasing. Does not update the composite image so this can be called

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -684,18 +684,20 @@ class TrackReview(CalibanWindow):
     def get_label(self):
         return int(self.tracked[self.current_frame, self.y, self.x])
 
+    def get_label_info(self, label):
+        info = self.tracks[label].copy()
+        frames = list(map(list, consecutive(info["frames"])))
+        frames = '[' + ', '.join(["{}".format(a[0])
+                            if len(a) == 1 else "{}-{}".format(a[0], a[-1])
+                            for a in frames]) + ']'
+        info["frames"] = frames
+        return info
+
     def draw_label(self):
         # always use segmented output for label, not raw
         label = self.get_label()
         if label != 0:
-            track = self.tracks[label].copy()
-            frames = list(map(list, consecutive(track["frames"])))
-            frames = '[' + ', '.join(["{}".format(a[0])
-                                if len(a) == 1 else "{}-{}".format(a[0], a[-1])
-                                for a in frames]) + ']'
-
-            track["frames"] = frames
-            text = '\n'.join("{:10} {}".format(k+':', track[k])
+            text = '\n'.join("{:10} {}".format(k+':', self.get_label_info(label)[k])
                              for k in self.display_info)
         else:
             text = ''
@@ -2315,6 +2317,9 @@ class ZStackReview(CalibanWindow):
         '''
         return (self.get_max_label() + 1)
 
+    def get_label_info(self, label):
+        return self.cell_info[self.feature][label]
+
     def draw_label(self):
         '''
         Coordinates information display (text) on left side of screen.
@@ -2337,7 +2342,7 @@ class ZStackReview(CalibanWindow):
 
         if label != 0:
             # generate text from cell_info and display_info (use slices instead of frames)
-            text = '\n'.join("{:10}{}".format(str(k)+':', self.cell_info[self.feature][label][k])
+            text = '\n'.join("{:10}{}".format(str(k)+':', self.get_label_info(label)[k])
                               for k in self.display_info)
         # display nothing if not hovering over a label
         else:

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -632,8 +632,8 @@ class TrackReview(CalibanWindow):
             return
 
         if not self.edit_mode:
+            label = self.get_label()
             if self.mode.kind is None:
-                label = self.get_label()
                 if label != 0:
                     self.mode.update("SELECTED",
                                      label=label,
@@ -642,7 +642,6 @@ class TrackReview(CalibanWindow):
                     self.highlighted_cell_one = label
                     self.highlighted_cell_two = -1
             elif self.mode.kind == "SELECTED":
-                label = self.get_label()
                 if label != 0:
                     self.highlighted_cell_one = self.mode.label
                     self.highlighted_cell_two = label
@@ -662,7 +661,6 @@ class TrackReview(CalibanWindow):
                     self.highlighted_cell_two = -1
             #if already have two cells selected, click again to reselect the second cell
             elif self.mode.kind == "MULTIPLE":
-                label = self.get_label()
                 if label != 0:
                     self.highlighted_cell_two = label
                     self.mode.update("MULTIPLE",
@@ -680,12 +678,11 @@ class TrackReview(CalibanWindow):
                     self.highlighted_cell_one = -1
                     self.highlighted_cell_two = -1
             elif self.mode.kind == "PROMPT" and self.mode.action == "FILL HOLE":
-                    label = self.get_label()
-                    if label == 0:
-                        self.hole_fill_seed = (self.y, self.x)
-                    if self.hole_fill_seed is not None:
-                        self.action_fill_hole()
-                        self.mode.clear()
+                if label == 0:
+                    self.hole_fill_seed = (self.y, self.x)
+                if self.hole_fill_seed is not None:
+                    self.action_fill_hole()
+                    self.mode.clear()
 
         elif self.edit_mode:
             if self.mode.kind is None:

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -475,7 +475,7 @@ class CalibanWindow:
         return text
 
 class CalibanBrush:
-    def __init__(self):
+    def __init__(self, height, width):
         self.size = 1
         self.edit_val = 1
         self.erase = False
@@ -483,11 +483,15 @@ class CalibanBrush:
         self.conv_target = -1
         self.conv_val = -1
 
+        # used to put bounds on size, area of brush
+        self.height = height
+        self.width = width
+
     def decrease_size(self):
         self.size = max(1, self.size -1)
 
-    def increase_size(self, window):
-        self.size = min(self.size + 1, window.height, window.width)
+    def increase_size(self):
+        self.size = min(self.size + 1, self.height, self.width)
 
     def decrease_edit_val(self):
         self.edit_val = max(1, self.edit_val - 1)
@@ -545,7 +549,7 @@ class TrackReview(CalibanWindow):
         self.hole_fill_seed = None
 
         self.brush_view = np.zeros(self.tracked[self.current_frame,:,:,0].shape)
-        self.brush = CalibanBrush()
+        self.brush = CalibanBrush(self.height, self.width)
 
         pyglet.app.run()
 
@@ -744,7 +748,7 @@ class TrackReview(CalibanWindow):
             if symbol == key.LEFT:
                 self.brush.decrease_size()
             if symbol == key.RIGHT:
-                self.brush.increase_size(window = self)
+                self.brush.increase_size()
             if symbol == key.Z:
                 self.draw_raw = not self.draw_raw
             else:
@@ -1336,7 +1340,7 @@ class ZStackReview(CalibanWindow):
 
         # brush_view is array used to display a preview of brush tool; same size as other arrays
         self.brush_view = np.zeros(self.annotated[self.current_frame,:,:,self.feature].shape)
-        self.brush = CalibanBrush()
+        self.brush = CalibanBrush(self.height, self.width)
 
         # not a user-toggled option; distinguishes between brush and threshold choices
         self.show_brush = True
@@ -2076,7 +2080,7 @@ class ZStackReview(CalibanWindow):
                 self.update_brushview_helper()
             # increase brush size
             if symbol == key.UP:
-                self.brush.increase_size(window = self)
+                self.brush.increase_size()
                 self.update_brushview_helper()
 
         # SET CONVERSION BRUSH VALUE TO UNUSED LABEL

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -2378,19 +2378,9 @@ class ZStackReview(CalibanWindow):
 
         # only display while in pixel-editing mode
         if self.edit_mode:
-            brush_size_display = "brush size: {}".format(self.brush_size)
-            edit_label_display = "editing label: {}".format(self.edit_value)
-            if self.erase:
-                erase_mode = "on"
-            else:
-                erase_mode = "off"
-            draw_or_erase = "eraser mode: {}".format(erase_mode)
-
             # TODO: render label in a batch
             # create pyglet label anchored to middle of left side
-            edit_label = pyglet.text.Label('{}\n{}\n{}'.format(brush_size_display,
-                                                        edit_label_display,
-                                                        draw_or_erase),
+            edit_label = pyglet.text.Label(self.create_brush_text(),
                                             font_name='monospace',
                                             anchor_x='left', anchor_y='center',
                                             width=self.sidebar_width,
@@ -2448,6 +2438,26 @@ class ZStackReview(CalibanWindow):
                     + "\nHistogram equalization - {}".format(on_or_off(self.adapthist_on)))
 
         return filter_text
+
+    def create_brush_text(self):
+        size_text = "Brush size: "
+        if self.show_brush:
+            size_text += str(self.brush_size)
+        else:
+            size_text += "-"
+
+        value_text = "Editing label: "
+        erase_text = "Eraser: "
+        if self.mode.kind is None:
+            value_text += str(self.edit_value)
+            erase_text += on_or_off(self.erase)
+        else:
+            value_text += "-"
+            erase_text += "-"
+
+        brush_info_text = "{}\n{}\n{}".format(size_text, value_text, erase_text)
+
+        return brush_info_text
 
     def render_frame_info_helper(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -297,6 +297,15 @@ class CalibanWindow:
                      left, top))
         )
 
+    def draw_current_frame(self):
+        if self.edit_mode:
+            self.draw_pixel_edit_frame()
+        else:
+            if self.draw_raw:
+                self.draw_raw_frame()
+            else:
+                self.draw_ann_frame()
+
     def draw_raw_frame(self):
         raw_array = self.get_raw_current_frame()
         adjusted_raw = self.apply_raw_image_adjustments(raw_array, cmap = self.current_cmap)
@@ -1063,20 +1072,6 @@ class TrackReview(CalibanWindow):
 
         info_label.draw()
         frame_label.draw()
-
-    def draw_current_frame(self):
-        if not self.edit_mode:
-            if self.draw_raw:
-                self.draw_raw_frame()
-            else:
-                self.draw_ann_frame()
-
-        elif self.edit_mode:
-            self.draw_pixel_edit_frame()
-
-        gl.glTexParameteri(gl.GL_TEXTURE_2D,
-                           gl.GL_TEXTURE_MAG_FILTER,
-                           gl.GL_NEAREST)
 
     def action_new_track(self):
         """
@@ -2691,24 +2686,6 @@ class ZStackReview(CalibanWindow):
                                         color=[255]*4)
         # draw the label
         frame_label.draw()
-
-    def draw_current_frame(self):
-        '''
-        Draw the current image view. Depending on the viewing mode (pixel-editing
-        or label-editing, raw or annotation view), takes the appropriate input array,
-        and applies adjustments as needed (eg, applying filters to the raw image). A
-        png format image is then created using pyplot and an appropriate colormap, then
-        loaded as a pyglet image, which is then scaled and drawn on the window. Several
-        helper functions are used to abstract steps of the image processing and manipulation.
-        '''
-        if not self.edit_mode:
-            if self.draw_raw:
-                self.draw_raw_frame()
-            else:
-                self.draw_ann_frame()
-
-        elif self.edit_mode:
-            self.draw_pixel_edit_frame()
 
     def change_channel(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -2495,19 +2495,17 @@ class ZStackReview(CalibanWindow):
                                                     cmap = 'gist_stern',
                                                     output = 'pyglet')
 
-        # get raw and annotated data
-        # TODO: np.copy might be appropriate here for clarity
-        # (current_raw is not edited in place but np.copy would help safeguard that)
-        current_raw = self.get_raw_current_frame()
-
-        current_raw, vmax = self.apply_image_adjustments_helper(current_raw)
-
         # create pyglet image from only the adjusted raw, if hiding annotations
         if self.hide_annotations:
-            comp_img = self.array_to_img(input_array = current_raw,
-                                                    vmax = vmax,
-                                                    cmap = 'gray',
-                                                    output = 'pyglet')
+            # get raw and annotated data
+            # TODO: np.copy might be appropriate here for clarity
+            # (current_raw is not edited in place but np.copy would help safeguard that)
+            current_raw = self.get_raw_current_frame()
+            raw_RGB = self.apply_raw_image_adjustments(current_raw)
+            comp_img = self.array_to_img(input_array = raw_RGB,
+                                        vmax = None,
+                                        cmap = None,
+                                        output = 'pyglet')
 
         # create pyglet image from composite if you want to see annotation overlay
         # (self.composite view is generated/updated separately)
@@ -2524,29 +2522,44 @@ class ZStackReview(CalibanWindow):
         self.draw_pyglet_image(comp_img)
         self.draw_pyglet_image(brush_img, opacity = 128)
 
-    def apply_image_adjustments_helper(self, current_raw):
+    def apply_raw_image_adjustments(self, current_raw, cmap = 'gray'):
         '''
         Apply filter/adjustment options to raw image for display in
         pixel-editing mode. Input is unadjusted raw image, with object
-        attributes to determine which filters and adjustments to apply.
-        Returns adjusted image and vmax (appropriate vmax depends on whether
-        or not image histogram has been equalized).
+        attributes to determine which filters and adjustments to apply. Can
+        accept cmap as input, default value of 'gray' (used for composite images).
+
+        Returns adjusted image as RGB array.
         '''
         #try sobel filter here
         if self.sobel_on:
             current_raw = filters.sobel(current_raw)
 
+        # apply adaptive histogram equalization, if option toggled
         if self.adapthist_on:
+            # rescale first (for equalization to work properly, I think)
             current_raw = rescale_intensity(current_raw, in_range = 'image', out_range = 'float')
             current_raw = equalize_adapthist(current_raw)
+            # vmax appropriate for new range of image
             vmax = 1
         elif not self.adapthist_on:
+            # appropriate vmax for image
             vmax = self.max_intensity
 
-        if self.invert:
-            current_raw = invert(current_raw)
+        # want image to be in grayscale, but as RGB array, not array of intensities
+        raw_img =  self.array_to_img(input_array = current_raw,
+                    vmax = vmax,
+                    cmap = cmap,
+                    output = 'array')
 
-        return current_raw, vmax
+        # don't need alpha channel
+        raw_RGB = raw_img[:,:,0:3]
+
+        # apply dark/light inversion
+        if self.invert:
+            raw_RGB = invert(raw_RGB)
+
+        return raw_RGB
 
     def change_channel(self):
         '''
@@ -3181,33 +3194,7 @@ class ZStackReview(CalibanWindow):
         current_raw = self.get_raw_current_frame()
         current_ann = self.get_ann_current_frame()
 
-        #try sobel filter here
-        if self.sobel_on:
-            current_raw = filters.sobel(current_raw)
-
-        # apply adaptive histogram equalization, if option toggled
-        if self.adapthist_on:
-            # rescale first (for equalization to work properly, I think)
-            current_raw = rescale_intensity(current_raw, in_range = 'image', out_range = 'float')
-            current_raw = equalize_adapthist(current_raw)
-            # vmax appropriate for new range of image
-            vmax = 1
-        elif not self.adapthist_on:
-            # appropriate vmax for image
-            vmax = self.max_intensity
-
-        # want image to be in grayscale, but as RGB array, not array of intensities
-        raw_img =  self.array_to_img(input_array = current_raw,
-                    vmax = vmax,
-                    cmap = 'gray',
-                    output = 'array')
-
-        # don't need alpha channel
-        raw_RGB = raw_img[:,:,0:3]
-
-        # apply dark/light inversion
-        if self.invert:
-            raw_RGB = invert(raw_RGB)
+        raw_RGB = self.apply_raw_image_adjustments(current_raw)
 
         # get RGB array of colorful annotation view
         ann_img = self.array_to_img(input_array = current_ann,

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -631,6 +631,27 @@ class CalibanWindow:
         # set self.composite view to new composite image
         self.composite_view = img_masked
 
+    def draw_cell_info_label(self):
+        '''
+        When cursor is over a label, displays information about that label
+        at the bottom of the information column.
+        '''
+        text = self.create_label_info_text()
+
+        # add info from self.mode (eg, prompts or "selected", etc)
+        text += self.mode.text
+
+        # TODO: render label in a batch
+        # create pyglet label anchored to bottom of left side
+        cell_info_label = pyglet.text.Label(text, font_name="monospace",
+                                       anchor_x="left", anchor_y="bottom",
+                                       width=self.sidebar_width,
+                                       multiline=True,
+                                       x=5, y=5, color=[255]*4)
+
+        # draw the label
+        cell_info_label.draw()
+
     def create_highlight_text(self):
         '''
         Generate text describing current highlighting status.
@@ -1097,14 +1118,6 @@ class TrackReview(CalibanWindow):
         return info
 
     def draw_label(self):
-        text = self.create_label_info_text()
-        text += self.mode.text
-
-        info_label = pyglet.text.Label(text, font_name="monospace",
-                                       anchor_x="left", anchor_y="bottom",
-                                       width=self.sidebar_width,
-                                       multiline=True,
-                                       x=5, y=5, color=[255]*4)
 
         if self.edit_mode:
             edit_mode = "on"
@@ -1141,7 +1154,7 @@ class TrackReview(CalibanWindow):
                                         x=5, y=self.window.height - 5,
                                         color=[255]*4)
 
-        info_label.draw()
+        self.draw_cell_info_label()
         frame_label.draw()
 
     def action_new_track(self):
@@ -2565,31 +2578,9 @@ class ZStackReview(CalibanWindow):
         '''
         # TODO: only update labels when the content changes?
         # TODO: batch graphics?
-        self.render_cell_label_info_helper()
+        self.draw_cell_info_label()
 
         self.render_frame_info_helper()
-
-    def render_cell_label_info_helper(self):
-        '''
-        When cursor is over a label, displays information about that label
-        at the bottom of the information column.
-        '''
-
-        text = self.create_label_info_text()
-
-        # add info from self.mode (eg, prompts or "selected", etc)
-        text += self.mode.text
-
-        # TODO: render label in a batch
-        # create pyglet label anchored to bottom of left side
-        cell_info_label = pyglet.text.Label(text, font_name="monospace",
-                                       anchor_x="left", anchor_y="bottom",
-                                       width=self.sidebar_width,
-                                       multiline=True,
-                                       x=5, y=5, color=[255]*4)
-
-        # draw the label
-        cell_info_label.draw()
 
     def create_disp_image_text(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -405,8 +405,7 @@ class TrackReview(CalibanWindow):
 
         if not self.edit_mode:
             if self.mode.kind is None:
-                frame = self.tracked[self.current_frame]
-                label = int(frame[self.y, self.x])
+                label = self.get_label()
                 if label != 0:
                     self.mode.update("SELECTED",
                                      label=label,
@@ -415,8 +414,7 @@ class TrackReview(CalibanWindow):
                     self.highlighted_cell_one = label
                     self.highlighted_cell_two = -1
             elif self.mode.kind == "SELECTED":
-                frame = self.tracked[self.current_frame]
-                label = int(frame[self.y, self.x])
+                label = self.get_label()
                 if label != 0:
                     self.highlighted_cell_one = self.mode.label
                     self.highlighted_cell_two = label
@@ -436,8 +434,7 @@ class TrackReview(CalibanWindow):
                     self.highlighted_cell_two = -1
             #if already have two cells selected, click again to reselect the second cell
             elif self.mode.kind == "MULTIPLE":
-                frame = self.tracked[self.current_frame]
-                label = int(frame[self.y, self.x])
+                label = self.get_label()
                 if label != 0:
                     self.highlighted_cell_two = label
                     self.mode.update("MULTIPLE",
@@ -455,8 +452,7 @@ class TrackReview(CalibanWindow):
                     self.highlighted_cell_one = -1
                     self.highlighted_cell_two = -1
             elif self.mode.kind == "PROMPT" and self.mode.action == "FILL HOLE":
-                    frame = self.tracked[self.current_frame]
-                    label = int(frame[self.y, self.x])
+                    label = self.get_label()
                     if label == 0:
                         self.hole_fill_seed = (self.y, self.x)
                     if self.hole_fill_seed is not None:
@@ -492,8 +488,7 @@ class TrackReview(CalibanWindow):
                 self.tracked[self.current_frame,:,:,0] = annotated
 
             elif self.mode.kind == "PROMPT" and self.mode.action == "PICK COLOR":
-                frame = self.tracked[self.current_frame]
-                label = int(frame[self.y, self.x, 0])
+                label = self.get_label()
                 if label == 0:
                     self.mode.clear()
                 elif label != 0:
@@ -686,10 +681,12 @@ class TrackReview(CalibanWindow):
     def get_ann_current_frame(self):
         return self.tracked[self.current_frame,:,:,0]
 
+    def get_label(self):
+        return int(self.tracked[self.current_frame, self.y, self.x])
+
     def draw_label(self):
         # always use segmented output for label, not raw
-        frame = self.tracked[self.current_frame]
-        label = int(frame[self.y, self.x])
+        label = self.get_label()
         if label != 0:
             track = self.tracks[label].copy()
             frames = list(map(list, consecutive(track["frames"])))

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -535,6 +535,9 @@ class CalibanBrush:
     def update_area(self):
         self.area = circle(self.y, self.x, self.size, (self.height, self.width))
 
+    def clear_view(self):
+        self.view = np.zeros((self.height, self.width))
+
 class TrackReview(CalibanWindow):
     possible_keys = {"label", "daughters", "frames", "parent", "frame_div",
                      "capped"}
@@ -713,7 +716,7 @@ class TrackReview(CalibanWindow):
 
     def on_mouse_release(self, x, y, buttons, modifiers):
         if self.edit_mode:
-            self.brush.view = np.zeros(self.brush.view.shape)
+            self.brush.clear_view()
             self.helper_update_composite()
 
     def on_mouse_scroll(self, x, y, scroll_x, scroll_y):
@@ -733,7 +736,7 @@ class TrackReview(CalibanWindow):
 
         if self.edit_mode:
             #display brush size
-            self.brush.view = np.zeros(self.brush.view.shape)
+            self.brush.clear_view()
             self.brush.view[self.brush.area] = self.brush.edit_val
 
     def on_key_press(self, symbol, modifiers):
@@ -1617,7 +1620,7 @@ class ZStackReview(CalibanWindow):
             # dragging the bounding box for threshold prediction
             elif not self.show_brush and self.mode.action == "DRAW BOX":
                 # reset self.brush.view
-                self.brush.view = np.zeros(self.brush.view.shape)
+                self.brush.clear_view()
 
                 # use self.brush.view to display a box; need to calculate min/max
                 # or else box will not always display
@@ -1808,7 +1811,7 @@ class ZStackReview(CalibanWindow):
                 preview of brush
         '''
         # clear old brush_view
-        self.brush.view = np.zeros(self.brush.view.shape)
+        self.brush.clear_view()
         # color/value of brush view depends on which brush mode we are in
         if self.mode.kind == "DRAW":
             self.brush.view[self.brush.area] = self.brush.conv_val
@@ -2064,7 +2067,7 @@ class ZStackReview(CalibanWindow):
         if symbol == key.T:
             self.mode.update("PROMPT", action = "DRAW BOX", **self.mode.info)
             self.show_brush = False
-            self.brush.view = np.zeros(self.brush.view.shape)
+            self.brush.clear_view()
 
     def edit_mode_misc_keypress_helper(self, symbol, modifiers):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -683,6 +683,30 @@ class CalibanWindow:
 
         return filter_text
 
+    def create_brush_text(self):
+        if self.edit_mode:
+            size_text = "Brush size: "
+            if self.brush.show:
+                size_text += str(self.brush.size)
+            else:
+                size_text += "-"
+
+            value_text = "Editing label: "
+            erase_text = "Eraser: "
+            if self.mode.kind is None:
+                value_text += str(self.brush.edit_val)
+                erase_text += on_or_off(self.brush.erase)
+            else:
+                value_text += "-"
+                erase_text += "-"
+
+            brush_info_text = "Current brush settings:\n\n{}\n{}\n{}".format(size_text,
+                value_text, erase_text)
+        else:
+            brush_info_text = ""
+
+        return brush_info_text
+
     def create_label_info_text(self):
         label = self.get_label()
         if label != 0:
@@ -2621,30 +2645,6 @@ class ZStackReview(CalibanWindow):
                 cmap = "cubehelix"
 
         return cmap
-
-    def create_brush_text(self):
-        if self.edit_mode:
-            size_text = "Brush size: "
-            if self.brush.show:
-                size_text += str(self.brush.size)
-            else:
-                size_text += "-"
-
-            value_text = "Editing label: "
-            erase_text = "Eraser: "
-            if self.mode.kind is None:
-                value_text += str(self.brush.edit_val)
-                erase_text += on_or_off(self.brush.erase)
-            else:
-                value_text += "-"
-                erase_text += "-"
-
-            brush_info_text = "Current brush settings:\n\n{}\n{}\n{}".format(size_text,
-                value_text, erase_text)
-        else:
-            brush_info_text = ""
-
-        return brush_info_text
 
     def render_frame_info_helper(self):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -380,7 +380,6 @@ class TrackReview(CalibanWindow):
 
         # `label` should appear first
         self.display_info = ["label", *sorted(set(self.tracks[1]) - {"label"})]
-        self.num_tracks = max(self.tracks)
 
         self.num_frames, self.height, self.width, _ = raw.shape
         self.dtype_raw = raw.dtype
@@ -557,7 +556,7 @@ class TrackReview(CalibanWindow):
                 raw_adjust = max(int(self.max_intensity * 0.02), 1)
                 self.max_intensity = max(self.max_intensity - raw_adjust * scroll_y, 2)
         else:
-            if self.num_tracks + (self.adjustment - 1 * scroll_y) > 0:
+            if self.get_max_label() + (self.adjustment - 1 * scroll_y) > 0:
                 self.adjustment = self.adjustment - 1 * scroll_y
 
     def on_mouse_motion(self, x, y, dx, dy):
@@ -592,7 +591,7 @@ class TrackReview(CalibanWindow):
 
         else:
             if symbol == key.EQUAL:
-                self.edit_value = min(self.edit_value + 1, self.num_tracks)
+                self.edit_value = min(self.edit_value + 1, self.get_max_label())
             if symbol == key.MINUS:
                 self.edit_value = max(self.edit_value - 1, 1)
             if symbol == key.X:
@@ -656,16 +655,16 @@ class TrackReview(CalibanWindow):
         #cycle through highlighted cells
         if symbol == key.EQUAL:
             if self.mode.kind == "SELECTED":
-                if self.highlighted_cell_one < self.num_tracks:
+                if self.highlighted_cell_one < self.get_max_label():
                     self.highlighted_cell_one += 1
-                elif self.highlighted_cell_one == self.num_tracks:
+                elif self.highlighted_cell_one == self.get_max_label():
                     self.highlighted_cell_one = 1
         if symbol == key.MINUS:
             if self.mode.kind == "SELECTED":
                 if self.highlighted_cell_one > 1:
                     self.highlighted_cell_one -= 1
                 elif self.highlighted_cell_one == 1:
-                    self.highlighted_cell_one = self.num_tracks
+                    self.highlighted_cell_one = self.get_max_label()
 
         if symbol == key.SPACE:
             if self.mode.kind == "QUESTION":
@@ -695,6 +694,9 @@ class TrackReview(CalibanWindow):
 
     def get_label(self):
         return int(self.tracked[self.current_frame, self.y, self.x])
+
+    def get_max_label(self):
+        return max(self.tracks)
 
     def get_label_info(self, label):
         info = self.tracks[label].copy()
@@ -801,7 +803,7 @@ class TrackReview(CalibanWindow):
 
         # create pyglet image
         image = self.array_to_img(input_array = ann_array,
-                                                vmax = self.num_tracks + self.adjustment,
+                                                vmax = self.get_max_label() + self.adjustment,
                                                 cmap = cmap,
                                                 output = 'pyglet')
         self.draw_pyglet_image(image)
@@ -809,7 +811,7 @@ class TrackReview(CalibanWindow):
     def draw_pixel_edit_frame(self):
         # create pyglet image object so we can display brush location
         brush_img = self.array_to_img(input_array = self.brush_view,
-                                                    vmax = self.num_tracks + self.adjustment,
+                                                    vmax = self.get_max_label() + self.adjustment,
                                                     cmap = 'gist_stern',
                                                     output = 'pyglet')
 
@@ -828,7 +830,7 @@ class TrackReview(CalibanWindow):
 
         # get RGB array of colorful annotation view
         ann_img = self.array_to_img(input_array = current_ann,
-                                            vmax = self.num_tracks + self.adjustment,
+                                            vmax = self.get_max_label() + self.adjustment,
                                             cmap = 'gist_stern',
                                             output = 'array')
 
@@ -849,8 +851,7 @@ class TrackReview(CalibanWindow):
         Replacing label
         """
         old_label, start_frame = self.mode.label, self.mode.frame
-        new_label = self.num_tracks + 1
-        self.num_tracks += 1
+        new_label = self.get_max_label() + 1
 
         if start_frame == 0:
             raise ValueError("new_track cannot be called on the first frame")
@@ -884,7 +885,7 @@ class TrackReview(CalibanWindow):
         Create new label in just one frame
         """
         old_label, single_frame = self.mode.label, self.mode.frame
-        new_label = self.num_tracks + 1
+        new_label = self.get_max_label() + 1
 
         # replace frame labels
         frame = self.tracked[single_frame]
@@ -897,7 +898,7 @@ class TrackReview(CalibanWindow):
     def action_watershed(self):
         # Pull the label that is being split and find a new valid label
         current_label = self.mode.label_1
-        new_label = self.num_tracks + 1
+        new_label = self.get_max_label() + 1
 
         # Locally store the frames to work on
         img_raw = self.raw[self.current_frame]
@@ -1067,8 +1068,6 @@ class TrackReview(CalibanWindow):
             self.tracks[add_label].update({'frame_div': None})
             self.tracks[add_label].update({'parent': None})
             self.tracks[add_label].update({'capped': False})
-
-            self.num_tracks += 1
 
     def del_cell_info(self, del_label, frame):
         '''

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -367,7 +367,7 @@ class TrackReview(CalibanWindow):
             print("Actions will not be supported")
 
         # `label` should appear first
-        self.track_keys = ["label", *sorted(set(self.tracks[1]) - {"label"})]
+        self.display_info = ["label", *sorted(set(self.tracks[1]) - {"label"})]
         self.num_tracks = max(self.tracks)
 
         self.num_frames, self.height, self.width, _ = raw.shape
@@ -699,7 +699,7 @@ class TrackReview(CalibanWindow):
 
             track["frames"] = frames
             text = '\n'.join("{:10} {}".format(k+':', track[k])
-                             for k in self.track_keys)
+                             for k in self.display_info)
         else:
             text = ''
 

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -520,6 +520,10 @@ class CalibanBrush:
     def set_conv_val(self, val):
         self.conv_val = val
 
+    def clear_conv(self):
+        self.conv_target = -1
+        self.conv_val = -1
+
     def update_center(self, y, x):
         self.y = y
         self.x = x
@@ -1958,6 +1962,8 @@ class ZStackReview(CalibanWindow):
             self.hole_fill_seed = None
             # reset self.mode (deselects labels, clears actions)
             self.mode.clear()
+            # reset conversion brush values
+            self.brush.clear_conv()
             # reset from thresholding
             self.show_brush = True
 


### PR DESCRIPTION
Initial refactoring into classes to make Caliban more modular. CalibanWindow class handles window size, binds window events, generates and draws text and images, and does some mouse event handling. CalibanWindow is now the parent class of TrackReview and ZStackReview. CalibanBrush stores brush attributes (different editing values, state of brush tool) and contains methods for updating its attributes and drawing. TrackReview and ZStackReview each create a CalibanBrush object upon initialization.

Minor visual improvements added: add a small blank border around each side of displayed image, display more information to sidebar about displayed image, view applied image adjustments while looking at raw image (in label-editing mode).

Minor changes to TrackReview: working with trk files is now more similar to working with npzs, as TrackReview now shares more display & mouse event code with ZStackReview.