### PR TITLE
Browser/feature/disable page scroll

### DIFF
--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -840,6 +840,21 @@ function action(action, info, frame = current_frame) {
 }
 
 function start_caliban(filename) {
+  // disable scrolling from scrolling around on page (it should just control brightness)
+  document.addEventListener('wheel', function(event) {
+    event.preventDefault();
+  }, {passive: false});
+  // disable space and up/down keys from moving around on page
+  $(document).on('keydown', function(event) {
+    if (event.key === " ") {
+      event.preventDefault();
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+    }
+  });
+
   load_file(filename);
   prepare_canvas();
   fetch_and_render_frame();

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1093,6 +1093,10 @@ function action(action, info, frame = current_frame) {
 }
 
 function start_caliban(filename) {
+  // disable scrolling from scrolling around on page (it should just control brightness)
+  document.addEventListener('wheel', function(event) {
+    event.preventDefault();
+  }, {passive: false});
   // disable space and up/down keys from moving around on page
   $(document).on('keydown', function(event) {
     if (event.key === " ") {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1093,6 +1093,16 @@ function action(action, info, frame = current_frame) {
 }
 
 function start_caliban(filename) {
+  // disable space and up/down keys from moving around on page
+  $(document).on('keydown', function(event) {
+    if (event.key === " ") {
+      event.preventDefault();
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+    }
+  });
   load_file(filename);
   prepare_canvas();
   fetch_and_render_frame();


### PR DESCRIPTION
Prevent scroll wheel and keys space, up, and down from scrolling page when working on trk or npz files. Makes it easier for annotators to use scroll and these keybinds for their intended functionality.