### PR TITLE
Update browser contrast adjustment

### DIFF
--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -50,6 +50,11 @@ class Mode {
       // toggle rendering_raw
       rendering_raw = !rendering_raw;
       render_image_display();
+    } else if (key === '0') {
+      // reset brightness adjustments
+      brightness = 0;
+      current_contrast = 0;
+      render_image_display();
     }
   }
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -596,6 +596,7 @@ var temp_y = 0;
 var rendering_raw = false;
 let display_invert = true;
 var current_contrast = 0;
+let brightness = 0;
 var current_frame = 0;
 var current_label = 0;
 var current_highlight = false;
@@ -648,11 +649,10 @@ function upload_file() {
 function contrast_image(img, contrast) {
   let d = img.data;
   contrast = (contrast / 100) + 1;
-  /* let intercept = 128 * (1 - contrast); */
   for (let i = 0; i < d.length; i += 4) {
-      d[i] *= contrast;
-      d[i + 1] *= contrast;
-      d[i + 2] *= contrast;
+      d[i] = d[i]*contrast + brightness;
+      d[i + 1] = d[i+1]*contrast + brightness;
+      d[i + 2] = d[i+2]*contrast + brightness;
   }
   return img;
 }
@@ -939,13 +939,18 @@ function load_file(file) {
 // adjust current_contrast upon mouse scroll
 function handle_scroll(evt) {
   // adjust contrast whenever we can see raw
-  if (rendering_raw || edit_mode) {
+  if ((rendering_raw || edit_mode) && !evt.originalEvent.shiftKey) {
     // don't use magnitude of scroll
     let mod_contrast = -Math.sign(evt.originalEvent.deltaY) * 4;
     // stop if fully desaturated
     current_contrast = Math.max(current_contrast + mod_contrast, -100);
     // stop at 5x contrast
     current_contrast = Math.min(current_contrast + mod_contrast, 400);
+    render_image_display();
+  } else if ((rendering_raw || edit_mode) && evt.originalEvent.shiftKey) {
+    let mod = -Math.sign(evt.originalEvent.deltaY);
+    brightness = Math.min(brightness + mod, 255);
+    brightness = Math.max(brightness + mod, -512);
     render_image_display();
   }
 }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -940,8 +940,12 @@ function load_file(file) {
 function handle_scroll(evt) {
   // adjust contrast whenever we can see raw
   if (rendering_raw || edit_mode) {
-    let delta = - evt.originalEvent.deltaY / 2;
-    current_contrast = Math.max(current_contrast + delta, -100);
+    // don't use magnitude of scroll
+    let mod_contrast = -Math.sign(evt.originalEvent.deltaY) * 4;
+    // stop if fully desaturated
+    current_contrast = Math.max(current_contrast + mod_contrast, -100);
+    // stop at 5x contrast
+    current_contrast = Math.min(current_contrast + mod_contrast, 400);
     render_image_display();
   }
 }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -81,6 +81,11 @@ class Mode {
       // toggle rendering_raw
       rendering_raw = !rendering_raw;
       render_image_display();
+    } else if (key === '0') {
+      // reset brightness adjustments
+      brightness = 0;
+      current_contrast = 0;
+      render_image_display();
     }
   }
 

--- a/browser/templates/infopane.html
+++ b/browser/templates/infopane.html
@@ -12,7 +12,9 @@
 
     <p><strong>Mouse</strong> over a cell mask to see cell label and lineage information.</p>
 
-    <p><strong>Scroll Wheel</strong> | In raw image or edit mode, scroll up/down to change the brightness of the image.&nbsp;</p>
+    <p><strong>Scroll Wheel</strong> | In raw image or edit mode, scroll up/down to change the contrast of the image. Hold down the shift key while scrolling to change the brightness. (These values can be reset by pressing 0.)&nbsp;</p>
+
+    <p><strong>0 (zero)</strong> | Reset the brightness and contrast settings, if viewing the raw image or in pixel-editing mode.&nbsp;</p>
 
     <p><strong>z</strong> | Switch between annotations and raw images; use this to check if your masks and labels match up to the actual cell image.</p>
 
@@ -64,7 +66,7 @@
 
     <p><em>Viewing:</em></p>
 
-    <p><strong>Scroll Wheel</strong> | Adjust brightness of raw image.</p>
+    <p><strong>Scroll Wheel</strong> | Adjust contrast of raw image. Hold down the shift key to change the brightness. (These values can be reset by pressing 0.)</p>
 
     <p><strong>h</strong> | Highlight mode; if used, pixels that match the current value of the brush will be displayed in red. (If using conversion brush, the label being overwritten does not change color, only the label that will replace it.)</p>
 


### PR DESCRIPTION
Adds brightness adjustment (shift+scroll), which helps visualize phase images. Stores brightness/contrast adjustments separately per channel for npz files. 0 (zero) key resets both brightness and contrast values. Scroll direction, not magnitude, determines adjustment so behavior is consistent across trackpad/mouse use. 