### PR TITLE
Add outline capability to browser

### DIFF
--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -24,6 +24,7 @@ from skimage.morphology import flood_fill, flood
 from skimage.draw import circle
 from skimage.measure import regionprops
 from skimage.exposure import rescale_intensity
+from skimage.segmentation import find_boundaries
 
 from config import S3_KEY, S3_SECRET
 
@@ -124,7 +125,20 @@ class ZStackReview:
 
     def get_array(self, frame):
         frame = self.annotated[frame][:,:,self.feature]
+        frame = self.add_outlines(frame)
         return frame
+
+    def add_outlines(self, frame):
+        '''
+        Helper function that indicates label outlines in array with
+        negative values of that label.
+        '''
+        # this is sometimes int 32 but may be uint, convert to
+        # int16 to ensure negative numbers and smaller payload than int32
+        frame = frame.astype(np.int16)
+        boundary_mask = find_boundaries(frame, mode = 'inner')
+        outlined_frame = np.where(boundary_mask == 1, -frame, frame)
+        return outlined_frame
 
     def load(self, filename):
 

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -479,7 +479,7 @@ function highlight(img, label) {
     for (var i = 0; i < seg_array[j].length; i += 1){ //x
       let jlen = seg_array[j].length;
 
-      if (seg_array[j][i] === label){
+      if (Math.abs(seg_array[j][i]) === label){
         // fill in all pixels affected by scale
         // k and l get the pixels that are part of the original pixel that has been scaled up
         for (var k = 0; k < scale; k +=1) {
@@ -525,7 +525,7 @@ function label_under_mouse() {
   let new_label;
   if (img_y >= 0 && img_y < seg_array.length &&
       img_x >= 0 && img_x < seg_array[0].length) {
-    new_label = seg_array[img_y][img_x]; //check array value at mouse location
+    new_label = Math.abs(seg_array[img_y][img_x]); //check array value at mouse location
   } else {
     new_label = 0;
   }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -684,6 +684,33 @@ function highlight(img, label) {
   }
 }
 
+function outline(img) {
+  let ann = img.data;
+  // use label array to figure out which pixels to recolor
+  for (var j = 0; j < seg_array.length; j += 1){ //y
+    for (var i = 0; i < seg_array[j].length; i += 1){ //x
+      let jlen = seg_array[j].length;
+
+      // label boundaries have negative values
+      if (seg_array[j][i] < 0) {
+        // fill in all pixels affected by scale
+        // k and l get the pixels that are part of the original pixel that has been scaled up
+        for (var k = 0; k < scale; k +=1) {
+          for (var l = 0; l < scale; l +=1) {
+            // location in 1D array based on i,j, and scale
+            pixel_num = (scale*(jlen*(scale*j + l) + i)) + k;
+
+            // set to red by changing RGB values
+            ann[(pixel_num*4)] = 255;
+            ann[(pixel_num*4) + 1] = 255;
+            ann[(pixel_num*4) + 2] = 255;
+          }
+        }
+      }
+    }
+  }
+}
+
 function grayscale(img) {
   let data = img.data;
   for (var i = 0; i < data.length; i += 4) {
@@ -838,6 +865,11 @@ function render_edit_image(ctx) {
     ctx.drawImage(seg_image, padding, padding, dimensions[0], dimensions[1]);
   }
   ctx.restore();
+
+  // to outline all edges:
+  // let composite = ctx.getImageData(padding, padding, dimensions[0], dimensions[1]);
+  // outline(composite);
+  // ctx.putImageData(composite, padding, padding);
 
   // draw brushview on top of cells/annotations
   ctx.save();

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -665,7 +665,7 @@ function highlight(img, label) {
     for (var i = 0; i < seg_array[j].length; i += 1){ //x
       let jlen = seg_array[j].length;
 
-      if (seg_array[j][i] === label){
+      if (Math.abs(seg_array[j][i]) === label){
         // fill in all pixels affected by scale
         // k and l get the pixels that are part of the original pixel that has been scaled up
         for (var k = 0; k < scale; k +=1) {
@@ -711,7 +711,7 @@ function label_under_mouse() {
   let new_label;
   if (img_y >= 0 && img_y < seg_array.length &&
       img_x >= 0 && img_x < seg_array[0].length) {
-    new_label = seg_array[img_y][img_x]; //check array value at mouse location
+    new_label = Math.abs(seg_array[img_y][img_x]); //check array value at mouse location
   } else {
     new_label = 0;
   }


### PR DESCRIPTION
Outline information about labels is sent by flipping the sign of labels in the array that gets sent to the frontend. Does not change how highlighting currently works in trk or npz files, but is a precursor to updating highlighting in those files + being able to show appropriate label overlays in RGB mode.