### PR TITLE
Initial timestamp tracking

### DIFF
--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -364,6 +364,12 @@ def delete_project(conn, project_id):
     '''
     cur = conn.cursor()
 
+    sql = ''' UPDATE {tn}
+              SET lastUpdate = updatedAt
+              WHERE id = {my_id}
+          '''.format(tn = 'projects', my_id = project_id)
+    cur.execute(sql)
+
     timesql = ''' UPDATE {tn}
                   SET finished = CURRENT_TIMESTAMP,
                       state = NULL
@@ -398,7 +404,8 @@ def main():
             updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
             finished TIMESTAMP,
             numUpdates integer NOT NULL DEFAULT 0,
-            firstUpdate TIMESTAMP
+            firstUpdate TIMESTAMP,
+            lastUpdate TIMESTAMP
         );
     """
     create_table(conn, sql_create_projects_table)

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -361,16 +361,6 @@ def main():
     """
     create_table(conn, sql_create_projects_table)
 
-    sql_create_timestamps_table = """
-        CREATE TABLE IF NOT EXISTS timestamps (
-            id integer NOT NULL AUTO_INCREMENT PRIMARY KEY,
-            filename text NOT NULL,
-            started TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-            finished TIMESTAMP DEFAULT '0000-00-00 00:00:00'
-        );
-    """
-    create_table(conn, sql_create_timestamps_table)
     conn.commit()
     conn.close()
 

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -282,20 +282,21 @@ def initial_connection():
             charset='utf8',
             use_unicode=True)
 
-        # on new server, caliban database won't exist yet
-        try:
-            query = '''CREATE DATABASE {}'''.format(config.MYSQL_DATABASE)
-            conn.cursor().execute(query)
-            conn.commit()
-
-        # it already exists
-        except:
-            pass
-
-        conn.close()
-
     except MySQLdb._exceptions.MySQLError as err:
         print('error', err)
+
+    # on new server, caliban database won't exist yet
+    try:
+        query = '''CREATE DATABASE {}'''.format(config.MYSQL_DATABASE)
+        conn.cursor().execute(query)
+        conn.commit()
+
+    # it already exists
+    except MySQLdb._exceptions.MySQLError as err:
+        print('error', err)
+
+    finally:
+        conn.close()
 
 
 def create_table(conn, create_table_sql):

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -26,7 +26,7 @@ app.config.from_object("config")
 def upload_file(project_id):
     ''' Upload .trk/.npz data file to AWS S3 bucket.
     '''
-    conn = create_connection("caliban.db")
+    conn = create_connection()
     # Use id to grab appropriate TrackReview/ZStackReview object from database
     id_exists = get_project(conn, project_id)
 
@@ -60,7 +60,7 @@ def action(project_id, action_type, frame):
     frame = int(frame)
 
     try:
-        conn = create_connection("caliban.db")
+        conn = create_connection()
         # Use id to grab appropriate TrackReview/ZStackReview object from database
         id_exists = get_project(conn, project_id)
 
@@ -112,7 +112,7 @@ def get_frame(frame, project_id):
         cells to .js file.
     '''
     frame = int(frame)
-    conn = create_connection("caliban.db")
+    conn = create_connection()
     # Use id to grab appropriate TrackReview/ZStackReview object from database
     id_exists = get_project(conn, project_id)
     conn.close()
@@ -144,7 +144,7 @@ def load(filename):
     ''' Initate TrackReview/ZStackReview object and load object to database.
         Send specific attributes of the object to the .js file.
     '''
-    conn = create_connection("caliban.db")
+    conn = create_connection()
 
     print(f"Loading track at {filename}", file=sys.stderr)
 
@@ -251,7 +251,7 @@ def shortcut(filename):
     }
     return jsonify(error), 400
 
-def create_connection(_):
+def create_connection():
     ''' Create a database connection to a MySQL database.
     '''
     conn = None
@@ -268,7 +268,7 @@ def create_connection(_):
         print(err)
     return conn
 
-def initial_connection(_):
+def initial_connection():
     ''' Create a connection to a MySQL server. Creates database if
     it doesn't exist yet. Only called when starting app.
     '''
@@ -406,8 +406,8 @@ def main():
     lastUpdate: timestamp that is null by default until file is uploaded, to
         accurately track the last change made to file before upload
     '''
-    initial_connection("caliban.db")
-    conn = create_connection("")
+    initial_connection()
+    conn = create_connection()
 
     sql_create_projects_table = """
         CREATE TABLE IF NOT EXISTS projects (

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -150,7 +150,7 @@ def load(filename):
 
     folders = re.split('__', filename)
     filename = folders[len(folders) - 1]
-    subfolders = folders[2:len(folders)-1]
+    subfolders = folders[2:len(folders) - 1]
 
     subfolders = '/'.join(subfolders)
     full_path = os.path.join(subfolders, filename)

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -328,6 +328,7 @@ def update_object(conn, project):
     sql = ''' UPDATE projects
               SET filename = %s ,
                   state = %s,
+                  firstUpdate = IF(numUpdates = 0, CURRENT_TIMESTAMP, firstUpdate),
                   numUpdates = numUpdates + 1
               WHERE id = %s'''
 
@@ -396,7 +397,8 @@ def main():
             createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
             updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
             finished TIMESTAMP,
-            numUpdates integer NOT NULL DEFAULT 0
+            numUpdates integer NOT NULL DEFAULT 0,
+            firstUpdate TIMESTAMP
         );
     """
     create_table(conn, sql_create_projects_table)

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -327,7 +327,8 @@ def update_object(conn, project):
     '''
     sql = ''' UPDATE projects
               SET filename = %s ,
-                  state = %s
+                  state = %s,
+                  numUpdates = numUpdates + 1
               WHERE id = %s'''
 
     # convert object to binary data to be stored as data type BLOB
@@ -394,7 +395,8 @@ def main():
             state longblob,
             createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
             updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
-            finished TIMESTAMP
+            finished TIMESTAMP,
+            numUpdates integer NOT NULL DEFAULT 0
         );
     """
     create_table(conn, sql_create_projects_table)

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -270,6 +270,35 @@ def create_connection(_):
         print(err)
     return conn
 
+def initial_connection(_):
+    ''' Create a connection to a MySQL server. Creates database if
+    it doesn't exist yet. Only called when starting app.
+    '''
+    try:
+        # connect but don't specify database: it might not exist
+        conn = MySQLdb.connect(
+            user=config.MYSQL_USERNAME,
+            host=config.MYSQL_HOSTNAME,
+            port=config.MYSQL_PORT,
+            passwd=config.MYSQL_PASSWORD,
+            charset='utf8',
+            use_unicode=True)
+
+        # on new server, caliban database won't exist yet
+        try:
+            query = '''CREATE DATABASE {}'''.format(config.MYSQL_DATABASE)
+            conn.cursor().execute(query)
+            conn.commit()
+
+        # it already exists
+        except:
+            pass
+
+        conn.close()
+
+    except MySQLdb._exceptions.MySQLError as err:
+        print('error', err)
+
 
 def create_table(conn, create_table_sql):
     ''' Create a table from the create_table_sql statement.
@@ -349,7 +378,8 @@ def delete_project(conn, project_id):
 def main():
     ''' Runs app and initiates database file if it doesn't exist.
     '''
-    conn = create_connection("caliban.db")
+    initial_connection("caliban.db")
+    conn = create_connection("")
     sql_create_projects_table = """
         CREATE TABLE IF NOT EXISTS projects (
             id integer NOT NULL AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
Adds some tracking metrics, including timestamps, to SQL database used with browser caliban. Instead of deleting row from database when file is finished, replaces long data blob with null to clear space. Keeps track of timestamps such as when file is opened and submitted. Keeps track of number of updates submitted to file. Helpful for determining how long files take to annotate, and how that time breaks down. Should also help database maintenance by making it easier to drop stale rows.

I think this is a solid start re: #109. I would be satisfied with closing that issue and opening a separate issue later if we need more advanced metrics or other changes to the SQL code.