### PR TITLE
Initial url options, RGB mode

### DIFF
--- a/browser/application.py
+++ b/browser/application.py
@@ -171,8 +171,9 @@ def load(filename):
         })
 
     if is_npz_file(filename):
+        rgb = request.args.get('rgb', default = False, type = bool)
         # Initate ZStackReview object and entry in database
-        zstack_review = ZStackReview(filename, input_bucket, output_bucket, subfolders)
+        zstack_review = ZStackReview(filename, input_bucket, output_bucket, subfolders, rgb)
         project_id = create_project(conn, filename, zstack_review)
         conn.commit()
         conn.close()

--- a/browser/application.py
+++ b/browser/application.py
@@ -171,7 +171,9 @@ def load(filename):
         })
 
     if is_npz_file(filename):
-        rgb = request.args.get('rgb', default = False, type = bool)
+        # arg is 'false' which gets parsed to True if casting to bool
+        rgb = request.args.get('rgb', type = str)
+        rgb = json.loads(rgb)
         # Initate ZStackReview object and entry in database
         zstack_review = ZStackReview(filename, input_bucket, output_bucket, subfolders, rgb)
         project_id = create_project(conn, filename, zstack_review)

--- a/browser/application.py
+++ b/browser/application.py
@@ -215,10 +215,21 @@ def tool():
     new_filename = 'caliban-input__caliban-output__test__{}'.format(
         str(filename))
 
+    # if no options passed (how this route will be for now),
+    # still want to pass in default settings
+    rgb = request.args.get('rgb', default = False, type = bool)
+    pixel_only = request.args.get('pixel_only', default = False, type = bool)
+    label_only = request.args.get('label_only', default = False, type = bool)
+    settings = {'rgb': rgb,
+                'pixel_only': pixel_only,
+                'label_only': label_only}
+
     if is_trk_file(new_filename):
         return render_template('index_track.html', filename=new_filename)
     if is_npz_file(new_filename):
-        return render_template('index_zstack.html', filename=new_filename)
+        return render_template('index_zstack.html',
+            filename=new_filename,
+            settings=settings)
 
     error = {
         'error': 'invalid file extension: {}'.format(
@@ -233,11 +244,20 @@ def shortcut(filename):
         request to access a specific data file that has been preloaded to the
         input S3 bucket (ex. http://127.0.0.1:5000/test.npz).
     '''
+    # if no options passed, we get default settings anyway
+    rgb = request.args.get('rgb', default = False, type = bool)
+    pixel_only = request.args.get('pixel_only', default = False, type = bool)
+    label_only = request.args.get('label_only', default = False, type = bool)
+    settings = {'rgb': rgb,
+                'pixel_only': pixel_only,
+                'label_only': label_only}
 
     if is_trk_file(filename):
         return render_template('index_track.html', filename=filename)
     if is_npz_file(filename):
-        return render_template('index_zstack.html', filename=filename)
+        return render_template('index_zstack.html',
+            filename=filename,
+            settings=settings)
 
     error = {
         'error': 'invalid file extension: {}'.format(

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -61,12 +61,6 @@ class ZStackReview:
 
             self.rescale_raw()
             self.reduce_to_RGB()
-            # elif self.dims == 4:
-            #     self.raw = np.squeeze(raw, axis = 0)
-            #     self.annotated = np.squeeze(annotated, axis = 0)
-            #     self.height, self.width, self.channel_max = self.raw.shape
-
-            # self.max_frames = 1
 
         else:
             self.max_frames, self.height, self.width, self.channel_max = self.raw.shape
@@ -132,7 +126,6 @@ class ZStackReview:
         self.rescaled = np.zeros((self.height, self.width, self.rgb_channels), dtype = 'uint8')
         # this approach allows noise through
         for channel in range(min(5, self.rgb_channels)):
-            print('rescaling channel', channel)
             self.rescaled[:,:,channel] = self.rescale_95(self.raw[0,:,:,channel])
 
     def reduce_to_RGB(self):
@@ -187,13 +180,13 @@ class ZStackReview:
         return cell_info
 
     def get_frame(self, frame, raw):
-        if raw and not self.rgb:
+        if (raw and not self.rgb):
             frame = self.raw[frame][:,:, self.channel]
             return pngify(imgarr=frame,
                           vmin=0,
                           vmax=self.max_intensity[self.channel],
                           cmap="cubehelix")
-        elif raw and self.rgb:
+        elif (raw and self.rgb):
             frame = self.rgb_img
             return pngify(imgarr=frame,
                 vmin=None, vmax=None, cmap=None)

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -36,7 +36,7 @@ s3 = boto3.client(
 )
 
 class ZStackReview:
-    def __init__(self, filename, input_bucket, output_bucket, subfolders):
+    def __init__(self, filename, input_bucket, output_bucket, subfolders, rgb = False):
 
         self.filename = filename
         self.input_bucket = input_bucket

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -365,7 +365,7 @@ def update_object(conn, state, project_id):
     state_data = pickle.dumps(state, pickle.HIGHEST_PROTOCOL)
 
     cur = conn.cursor()
-    cur.execute(sql, (state_data, project_id)
+    cur.execute(sql, (state_data, project_id))
     conn.commit()
 
 

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -176,10 +176,10 @@ def load(filename):
         })
 
     if is_npz_file(filename):
+        rgb = request.args.get('rgb', default = False, type = bool)
         # Initate ZStackReview object and entry in database
-        zstack_review = ZStackReview(filename, input_bucket, output_bucket, full_path)
+        zstack_review = ZStackReview(filename, input_bucket, output_bucket, full_path, rgb)
         project_id = create_project(conn, filename, zstack_review, subfolders)
-
         conn.commit()
         conn.close()
 

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -176,7 +176,9 @@ def load(filename):
         })
 
     if is_npz_file(filename):
-        rgb = request.args.get('rgb', default = False, type = bool)
+        # arg is 'false' which gets parsed to True if casting to bool
+        rgb = request.args.get('rgb', type = str)
+        rgb = json.loads(rgb)
         # Initate ZStackReview object and entry in database
         zstack_review = ZStackReview(filename, input_bucket, output_bucket, full_path, rgb)
         project_id = create_project(conn, filename, zstack_review, subfolders)

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -221,10 +221,21 @@ def tool():
     new_filename = 'caliban-input__caliban-output__test__{}'.format(
         str(filename))
 
+    # if no options passed (how this route will be for now),
+    # still want to pass in default settings
+    rgb = request.args.get('rgb', default = False, type = bool)
+    pixel_only = request.args.get('pixel_only', default = False, type = bool)
+    label_only = request.args.get('label_only', default = False, type = bool)
+    settings = {'rgb': rgb,
+                'pixel_only': pixel_only,
+                'label_only': label_only}
+
     if is_trk_file(new_filename):
         return render_template('index_track.html', filename=new_filename)
     if is_npz_file(new_filename):
-        return render_template('index_zstack.html', filename=new_filename)
+        return render_template('index_zstack.html',
+            filename=new_filename,
+            settings=settings)
 
     error = {
         'error': 'invalid file extension: {}'.format(
@@ -239,12 +250,25 @@ def shortcut(filename):
         request to access a specific data file that has been preloaded to the
         input S3 bucket (ex. http://127.0.0.1:5000/test.npz).
     '''
+    # if no options passed, we get default settings anyway
+    rgb = request.args.get('rgb', default = False, type = bool)
+    pixel_only = request.args.get('pixel_only', default = False, type = bool)
+    label_only = request.args.get('label_only', default = False, type = bool)
+    settings = {'rgb': rgb,
+                'pixel_only': pixel_only,
+                'label_only': label_only}
 
+    # TODO: could this be consolidated into one template with an "is_trk" toggle?
+    # note: not adding options to trk files yet
     if is_trk_file(filename):
         return render_template('index_track.html', filename=filename)
     if is_npz_file(filename):
-        return render_template('index_zstack.html', filename=filename)
+        return render_template('index_zstack.html',
+            filename=filename,
+            settings=settings)
 
+    # TODO: render an error template instead that shows which error,
+    # instead of sending json
     error = {
         'error': 'invalid file extension: {}'.format(
             os.path.splitext(filename)[-1])

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -124,7 +124,7 @@ class Mode {
 
   // keybinds that apply when in edit mode
   handle_edit_keybind(key) {
-    if (key === "e") {
+    if (key === "e" && !settings.pixel_only) {
       // toggle edit mode
       edit_mode = !edit_mode;
       render_image_display();
@@ -615,7 +615,7 @@ var scale;
 var mouse_x = 0;
 var mouse_y = 0;
 const padding = 5;
-var edit_mode = false;
+let edit_mode;
 var answer = "(SPACE=YES / ESC=NO)";
 let mousedown = false;
 var tooltype = 'draw';
@@ -1122,6 +1122,11 @@ function action(action, info, frame = current_frame) {
 }
 
 function start_caliban(filename) {
+  if (settings.pixel_only) {
+    edit_mode = true;
+  } else {
+    edit_mode = false;
+  }
   // disable scrolling from scrolling around on page (it should just control brightness)
   document.addEventListener('wheel', function(event) {
     event.preventDefault();

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -181,7 +181,7 @@ class Mode {
       this.prompt = "First, click on the label you want to overwrite.";
       brush.conv = true;
       render_image_display();
-    } else if (key === 't') {
+    } else if (key === 't' && !rgb) {
       // prompt thresholding with bounding box
       this.kind = Modes.question;
       this.action = "start_threshold";
@@ -221,7 +221,7 @@ class Mode {
         action("change_feature", this.info);
         this.clear();
       }
-    } else if (key === "p") {
+    } else if (key === "p" && !rgb) {
       //iou cell identity prediction
       this.kind = Modes.question;
       this.action = "predict";
@@ -298,7 +298,7 @@ class Mode {
       this.action = "swap_cells";
       this.prompt = "SPACE = SWAP IN ALL FRAMES / S = SWAP IN THIS FRAME ONLY / ESC = CANCEL SWAP";
       render_info_display();
-    } else if (key === "w" ) {
+    } else if (key === "w" && !rgb) {
       // watershed
       this.kind = Modes.question;
       this.action = "watershed";

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -88,6 +88,9 @@ class Mode {
       brightness = 0;
       current_contrast = 0;
       render_image_display();
+    } else if (key === 'l' && !edit_mode) {
+      display_labels = !display_labels;
+      render_image_display();
     }
   }
 
@@ -593,6 +596,7 @@ var temp_x = 0;
 var temp_y = 0;
 var rendering_raw = false;
 let display_invert = true;
+let display_labels = false;
 var current_contrast;
 let contrastMap = new Map();
 let brightness;
@@ -665,7 +669,7 @@ function highlight(img, label) {
             // location in 1D array based on i,j, and scale
             pixel_num = (scale*(jlen*(scale*j + l) + i)) + k;
 
-            if (rgb) {
+            if (rgb && !display_labels) {
               // set to white by changing RGB values
               ann[(pixel_num*4)] += 60;
               ann[(pixel_num*4) + 1] += 60;
@@ -846,10 +850,6 @@ function update_seg_highlight() {
   adjusted_seg.src = canvas.toDataURL();
 }
 
-// function rgb_highlight(ctx) {
-
-// }
-
 function outline_all(ctx) {
   // to outline all edges:
   let composite = ctx.getImageData(padding, padding, dimensions[0], dimensions[1]);
@@ -918,7 +918,9 @@ function render_raw_image(ctx) {
 }
 
 function render_annotation_image(ctx) {
-  if (!rgb) {
+  if (rgb && !display_labels) {
+    render_label_overlay(ctx);
+  } else {
     ctx.clearRect(padding, padding, dimensions[0], dimensions[1]);
     ctx.drawImage(seg_image, padding, padding, dimensions[0], dimensions[1]);
     if (current_highlight) {
@@ -927,8 +929,6 @@ function render_annotation_image(ctx) {
       highlight(img_data, mode.highlighted_cell_two);
       ctx.putImageData(img_data, padding, padding);
     }
-  } else {
-    render_label_overlay(ctx);
   }
 }
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -194,7 +194,7 @@ class Mode {
 
   // keybinds that apply in bulk mode, nothing selected
   handle_mode_none_keybind(key) {
-    if (key === "e") {
+    if (key === "e" && !settings.label_only) {
       // toggle edit mode
       edit_mode = !edit_mode;
       helper_brush_draw();
@@ -1177,7 +1177,7 @@ function action(action, info, frame = current_frame) {
 }
 
 function start_caliban(filename) {
-  if (settings.pixel_only) {
+  if (settings.pixel_only && !settings.label_only) {
     edit_mode = true;
   } else {
     edit_mode = false;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -695,8 +695,8 @@ function outline(img) {
     for (var i = 0; i < seg_array[j].length; i += 1){ //x
       let jlen = seg_array[j].length;
 
-      // label boundaries have negative values
-      if (seg_array[j][i] < 0) {
+      if (edit_mode && brush.conv && brush.target !== -1
+        && seg_array[j][i] === -brush.target) {
         // fill in all pixels affected by scale
         // k and l get the pixels that are part of the original pixel that has been scaled up
         for (var k = 0; k < scale; k +=1) {
@@ -705,6 +705,21 @@ function outline(img) {
             pixel_num = (scale*(jlen*(scale*j + l) + i)) + k;
 
             // set to red by changing RGB values
+            ann[(pixel_num*4)] = 255;
+            ann[(pixel_num*4) + 1] = 0;
+            ann[(pixel_num*4) + 2] = 0;
+          }
+        }
+      } else if (seg_array[j][i] < 0) {
+      // label boundaries have negative values
+        // fill in all pixels affected by scale
+        // k and l get the pixels that are part of the original pixel that has been scaled up
+        for (var k = 0; k < scale; k +=1) {
+          for (var l = 0; l < scale; l +=1) {
+            // location in 1D array based on i,j, and scale
+            pixel_num = (scale*(jlen*(scale*j + l) + i)) + k;
+
+            // set to white by changing RGB values
             ann[(pixel_num*4)] = 255;
             ann[(pixel_num*4) + 1] = 255;
             ann[(pixel_num*4) + 2] = 255;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -927,7 +927,7 @@ function fetch_and_render_frame() {
 function load_file(file) {
   $.ajax({
     type:'POST',
-    url:"load/" + file,
+    url:"load/" + file + `?&rgb=${settings.rgb}`,
     success: function (payload) {
       max_frames = payload.max_frames;
       feature_max = payload.feature_max;

--- a/browser/templates/index_zstack.html
+++ b/browser/templates/index_zstack.html
@@ -61,6 +61,7 @@
 <!-- START CALIBAN FUNCTION CALL -->
   <script>
     var file = "{{filename}}"
+    var settings = {{settings|tojson}}
 
     function upload() {
       document.getElementById("submit").innerHTML = "";


### PR DESCRIPTION
Add ability to parse optional url args (pixel_only, label_only, rgb). pixel_only and label_only disable certain keybinds to restrict range of functionality available to annotators. rgb toggles change in how images are displayed (how image is generated by server, how labels and overlay are displayed in frontend), and disables certain keybinds that are not relevant to multichannel images.

Addresses #92 (may want to expand on this before closing issue), closes #108.