### PR TITLE
Fix npz upload issues

### DIFF
--- a/browser/.ebextensions/healthcheckurl.config
+++ b/browser/.ebextensions/healthcheckurl.config
@@ -1,0 +1,4 @@
+option_settings:
+  - namespace:  aws:elasticbeanstalk:application
+    option_name:  Application Healthcheck URL
+    value:  /health

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -16,7 +16,6 @@ import tarfile
 import tempfile
 import boto3
 import sys
-from werkzeug.utils import secure_filename
 from skimage import filters
 import skimage.morphology
 from skimage.morphology import watershed

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -604,7 +604,7 @@ class ZStackReview:
     def action_save_zstack(self):
         # save file to BytesIO object
         store_npz = BytesIO()
-        np.savez(store_npz, raw = self.raw, annotated = self.annotated)
+        np.savez(store_npz, raw=self.raw, annotated=self.annotated)
         store_npz.seek(0)
 
         # store npz file object in bucket/subfolders (subfolders is full path)

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -22,6 +22,11 @@ app = application
 app.config.from_object("config")
 
 
+@app.route("/health")
+def healthcheck():
+    '''Lets elastic beanstalk know when this app is ready to use'''
+    return 'success'
+
 @app.route("/upload_file/<project_id>", methods=["GET", "POST"])
 def upload_file(project_id):
     ''' Upload .trk/.npz data file to AWS S3 bucket.

--- a/browser/eb_application.py
+++ b/browser/eb_application.py
@@ -23,7 +23,7 @@ app.config.from_object("config")
 
 
 @app.route("/health")
-def healthcheck():
+def health():
     '''Lets elastic beanstalk know when this app is ready to use'''
     return 'success'
 


### PR DESCRIPTION
Create health-check route and configure elastic beanstalk to use it, closes #86 (prevents file uploads from getting lost).
Upload npz and trk files to s3 from file objects, not files saved to disk, closes #106.