### PR TITLE
Update npz canvas (expansion, better scaling, pan+zoom)

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -107,7 +107,7 @@ Keybinds in pixel editing mode are different from those in the label-editing mod
 
 Annotation mode focuses on using an adjustable brush to modify annotations on a pixel level, rather than using operations that apply to every instance of a label within a frame or set of frames. The brush tool will only make changes to the currently selected value. Ie, a brush set to edit cell 5 will only add or erase "5" to the annotated image.
 
-*-/=* - increment value that brush is applying
+*[ (left bracket) / ] (right bracket)* - increment value that brush is applying
 
 *&darr; &uarr;* - change size of brush tool
 
@@ -125,6 +125,10 @@ Annotation mode focuses on using an adjustable brush to modify annotations on a 
 
 
 ### Viewing Options:
+
+*spacebar + click and drag* - pan across canvas
+
+*-/= keys or alt + scroll wheel* - zoom in and out
 
 *c* - cycle between different channels when no cells are selected
 

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -182,8 +182,7 @@ def load(filename):
             'feature_max': zstack_review.feature_max,
             'tracks': zstack_review.readable_tracks,
             'dimensions': zstack_review.dimensions,
-            'project_id': project.id,
-            'screen_scale': zstack_review.scale_factor
+            'project_id': project.id
         })
 
     error = {

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -74,7 +74,6 @@ class ZStackReview:
             self.max_intensity[channel] = None
 
         self.dtype_raw = self.raw.dtype
-        self.scale_factor = 2
 
         self.save_version = 0
 
@@ -372,10 +371,7 @@ class ZStackReview:
 
         in_original = np.any(np.isin(img_ann, old_label))
 
-        filled_img_ann = flood_fill(img_ann,
-                                    (int(y_location / self.scale_factor),
-                                     int(x_location / self.scale_factor)),
-                                    new_label)
+        filled_img_ann = flood_fill(img_ann, (y_location, x_location), new_label)
         self.annotated[frame, :, :, self.feature] = filled_img_ann
 
         in_modified = np.any(np.isin(filled_img_ann, old_label))
@@ -393,8 +389,7 @@ class ZStackReview:
         '''
 
         img_ann = self.annotated[frame, :, :, self.feature]
-        contig_cell = flood(image=img_ann, seed_point=(int(y_location / self.scale_factor),
-                                                       int(x_location / self.scale_factor)))
+        contig_cell = flood(image=img_ann, seed_point=(y_location, x_location))
         img_trimmed = np.where(np.logical_and(np.invert(contig_cell), img_ann == label), 0, img_ann)
 
         # check if image changed
@@ -412,8 +407,7 @@ class ZStackReview:
         size, then fills the hole with label (using skimage flood_fill). connectivity = 1
         prevents hole fill from spilling out into background in some cases
         '''
-        # rescale click location -> corresponding location in annotation array
-        hole_fill_seed = (y_location // self.scale_factor, x_location // self.scale_factor)
+        hole_fill_seed = (y_location, x_location)
         # fill hole with label
         img_ann = self.annotated[frame, :, :, self.feature]
         filled_img_ann = flood_fill(img_ann, hole_fill_seed, label, connectivity=1)
@@ -537,10 +531,8 @@ class ZStackReview:
         # define a new seeds labeled img that is the same size as raw/annotation imgs
         seeds_labeled = np.zeros(img_ann.shape)
         # create two seed locations
-        seeds_labeled[int(y1_location / self.scale_factor),
-                      int(x1_location / self.scale_factor)] = current_label
-        seeds_labeled[int(y2_location / self.scale_factor),
-                      int(x2_location / self.scale_factor)] = new_label
+        seeds_labeled[y1_location, x1_location] = current_label
+        seeds_labeled[y2_location, x2_location] = new_label
 
         # define the bounding box to apply the transform on and select
         # appropriate sections of 3 inputs (raw, seeds, annotation mask)

--- a/browser/static/css/main.css
+++ b/browser/static/css/main.css
@@ -30,20 +30,13 @@
 }
 
 #container {
-    margin: 0 auto;
-    margin-top: 100px;
+    margin: 20px;
     display: flex;
     box-sizing: border-box;
     flex-shrink: 0;
     flex-direction: row;
     justify-content: center;
-    align-items: center;
-}
-
-#maintable {
-    width: 900px;
-    height: 500px;
-    /* outline: 1px dashed blue; */
+    align-items: flex-start;
 }
 
 .changed-label {
@@ -57,6 +50,12 @@
     box-sizing: border-box;
     border-radius: 1em;
     width: 20em;
+}
+
+#canvascol {
+    display: flex;
+    justify-content: flex-start;
+    /*flex-grow: 1; */ /*turn this on to justify things to the left in page*/
 }
 
 #edit_brush_row, #edit_label_row, #edit_erase_row {
@@ -84,10 +83,6 @@
 
 #hidden_seg_canvas {
     display: none;
-}
-
-#canvascol {
-    vertical-align: top;
 }
 
 #give_filename {

--- a/browser/static/css/main.css
+++ b/browser/static/css/main.css
@@ -78,6 +78,7 @@
 
 #canvas {
     cursor: crosshair;
+    background: black;
     box-shadow: 0px 2px 4px -1px rgba(0, 0, 0, 0.2), 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
 }
 

--- a/browser/static/js/adjust.js
+++ b/browser/static/js/adjust.js
@@ -149,7 +149,9 @@ function compositeImages() {
   ctx.drawImage(contrastedRaw, 0, 0, rawWidth, rawHeight);
   let rawData = ctx.getImageData(0, 0, rawWidth, rawHeight);
   grayscale(rawData);
-  invert(rawData);
+  if (display_invert) {
+    invert(rawData);
+  }
   ctx.putImageData(rawData, 0, 0);
 
   // add labels on top

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -428,10 +428,7 @@ class Mode {
     }
   }
 
-  handle_threshold(evt) {
-    let end_y = evt.offsetY - padding;
-    let end_x = evt.offsetX - padding;
-
+  handle_threshold() {
     let threshold_start_y = brush.threshY;
     let threshold_start_x = brush.threshX;
     let threshold_end_x = imgX;
@@ -1180,13 +1177,13 @@ function handle_mousemove(evt) {
 }
 
 // handles end of click&drag (different from click())
-function handle_mouseup(evt) {
+function handle_mouseup() {
   mousedown = false;
   if (!spacedown) {
     if (mode.kind !== Modes.prompt) {
       if (edit_mode) {
         if (!brush.show) {
-          mode.handle_threshold(evt);
+          mode.handle_threshold();
         } else {
           //send click&drag coordinates to caliban.py to update annotations
           mode.handle_draw();
@@ -1218,10 +1215,7 @@ function prepare_canvas() {
     // handle brush preview
     handle_mousemove(evt);
   });
-  // bind mouse button release (end of click&drag)
-  $('#canvas').mouseup(function(evt) {
-    handle_mouseup(evt);
-  });
+  // mouse button release (end of click&drag) bound to document, not just canvas
   // bind keypress
   window.addEventListener('keydown', function(evt) {
     mode.handle_key(evt.key);
@@ -1300,6 +1294,10 @@ function start_caliban(filename) {
       event.preventDefault();
     }
   });
+
+  document.addEventListener('mouseup', function() {
+    handle_mouseup();
+   });
 
   // define image onload cascade behavior
   if (rgb) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -852,6 +852,7 @@ function render_info_display() {
   $('#frame').html(current_frame);
   $('#feature').html(mode.feature);
   $('#channel').html(mode.channel);
+  $('#zoom').html(`${zoom}%`);
 
   render_highlight_info();
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -678,6 +678,11 @@ const postCompImg = new Image();
 
 var seg_array; // declare here so it is global var
 
+let topBorder = new Path2D();
+let bottomBorder = new Path2D();
+let rightBorder = new Path2D();
+let leftBorder = new Path2D();
+
 var rendering_raw = false;
 let display_invert = true;
 let display_labels = false;
@@ -900,6 +905,44 @@ function render_annotation_image(ctx) {
   }
 }
 
+function drawBorders(ctx) {
+  ctx.save();
+  // left border
+  if (Math.floor(sx) === 0) {
+    ctx.fillStyle = 'white';
+  } else {
+    ctx.fillStyle = 'black';
+  }
+  ctx.fill(leftBorder);
+
+  // right border
+  if (Math.ceil(sx + swidth) === rawWidth) {
+    ctx.fillStyle = 'white';
+  } else {
+    ctx.fillStyle = 'black';
+  }
+  ctx.fill(rightBorder);
+
+  // top border
+  if (Math.floor(sy) === 0) {
+    ctx.fillStyle = 'white';
+  } else {
+    ctx.fillStyle = 'black';
+  }
+  ctx.fill(topBorder);
+
+  // bottom border
+  if (Math.ceil(sy + sheight) === rawHeight) {
+    ctx.fillStyle = 'white';
+  } else {
+    ctx.fillStyle = 'black';
+  }
+  ctx.fill(bottomBorder);
+
+  ctx.restore();
+}
+
+
 function render_image_display() {
   let ctx = $('#canvas').get(0).getContext("2d");
   ctx.imageSmoothingEnabled = false;
@@ -916,6 +959,7 @@ function render_image_display() {
     // draw annotations
     render_annotation_image(ctx);
   }
+  drawBorders(ctx);
   render_info_display();
 }
 
@@ -1008,6 +1052,31 @@ function setCanvasDimensions() {
   $('#canvas').get(0).height = dimensions[1] + 2*padding;
   $('#hidden_seg_canvas').get(0).width = rawWidth;
   $('#hidden_seg_canvas').get(0).height = rawHeight;
+
+  // create paths for recoloring borders
+  topBorder.moveTo(0, 0);
+  topBorder.lineTo(padding, padding);
+  topBorder.lineTo(dimensions[0] + padding, padding);
+  topBorder.lineTo(dimensions[0] + 2*padding, 0);
+  topBorder.closePath();
+
+  bottomBorder.moveTo(0, dimensions[1] + 2*padding);
+  bottomBorder.lineTo(padding, dimensions[1] + padding);
+  bottomBorder.lineTo(dimensions[0] + padding, dimensions[1] + padding);
+  bottomBorder.lineTo(dimensions[0] + 2*padding, dimensions[1] + 2*padding);
+  bottomBorder.closePath();
+
+  leftBorder.moveTo(0, 0);
+  leftBorder.lineTo(0, dimensions[1] + 2*padding);
+  leftBorder.lineTo(padding, dimensions[1] + padding);
+  leftBorder.lineTo(padding, padding);
+  leftBorder.closePath();
+
+  rightBorder.moveTo(dimensions[0] + 2*padding, 0);
+  rightBorder.lineTo(dimensions[0] + padding, padding);
+  rightBorder.lineTo(dimensions[0] + padding, dimensions[1] + padding);
+  rightBorder.lineTo(dimensions[0] + 2*padding, dimensions[1] + 2*padding);
+  rightBorder.closePath();
 }
 
 // adjust current_contrast upon mouse scroll

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -914,8 +914,15 @@ function load_file(file) {
 
 function setCanvasDimensions() {
   // calculate available space and how much to scale x and y to fill it
-  let availWidth = Math.floor(document.documentElement.clientWidth * 0.6);
-  let availHeight = Math.floor(document.documentElement.clientHeight * 0.8);
+  // only thing that shares width is the info display on left
+  let availWidth = Math.floor(document.documentElement.clientWidth * 0.75);
+
+  // leave space for navbar, instructions pane, and footer
+  let availHeight = Math.floor((document.documentElement.clientHeight -
+      document.getElementsByClassName('footer-text')[0].clientHeight -
+      document.getElementsByClassName('accordion')[0].clientHeight -
+      document.getElementsByClassName('navbar')[0].clientHeight)*0.95);
+
   let scaleX = Math.floor(availWidth/rawDimensions[0]);
   let scaleY = Math.floor(availHeight/rawDimensions[1]);
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -90,6 +90,10 @@ class Mode {
     } else if ((key === 'l' || key === 'L') && !edit_mode) {
       display_labels = !display_labels;
       render_image_display();
+    } else if (key === '-') {
+      changeZoom(1);
+    } else if (key === '=') {
+      changeZoom(-1);
     }
   }
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -853,6 +853,8 @@ function render_info_display() {
   $('#feature').html(mode.feature);
   $('#channel').html(mode.channel);
   $('#zoom').html(`${zoom}%`);
+  $('#displayedX').html(`${Math.floor(sx)}-${Math.ceil(sx+swidth)}`);
+  $('#displayedY').html(`${Math.floor(sy)}-${Math.ceil(sy+sheight)}`);
 
   render_highlight_info();
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -648,14 +648,21 @@ function upload_file() {
   });
 }
 
+// check if the mouse position in canvas matches to a displayed part of image
+function inRange(x, y) {
+  let scaledX = Math.floor(x/scale);
+  let scaledY = Math.floor(y/scale);
+  if (scaledX >= 0 && scaledX < seg_array[0].length &&
+      scaledY >= 0 && scaledY < seg_array.length) {
+    return true;
+  } else {
+    return false;
+  }
+}
 
 function label_under_mouse() {
   let new_label;
-  // convert to image indices, to use for actions and getting label
-  let tempImgX = Math.floor(canvasPosX/scale);
-  let tempImgY = Math.floor(canvasPosY/scale);
-  if (tempImgX >= 0 && tempImgX < seg_array[0].length &&
-      tempImgY >= 0 && tempImgY < seg_array.length) {
+  if (inRange(canvasPosX, canvasPosY)) {
     new_label = Math.abs(seg_array[imgY][imgX]); //check array value at mouse location
   } else {
     new_label = 0;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -152,7 +152,7 @@ class Mode {
         action("change_feature", this.info);
         this.clear();
       }
-    } else if (key === "=") {
+    } else if (key === "]") {
       // increase edit_value up to max label + 1 (guaranteed unused)
       brush.value = Math.min(brush.value + 1,
           maxLabelsMap.get(this.feature) + 1);
@@ -161,7 +161,7 @@ class Mode {
         preCompAdjust();
       }
       render_info_display();
-    } else if (key === "-") {
+    } else if (key === "[") {
       // decrease edit_value, minimum 1
       brush.value -= 1;
       if (current_highlight) {
@@ -233,7 +233,7 @@ class Mode {
       this.action = "predict";
       this.prompt = "Predict cell ids for zstack? / S=PREDICT THIS FRAME / SPACE=PREDICT ALL FRAMES / ESC=CANCEL PREDICTION";
       render_info_display();
-    } else if (key === "-" && this.highlighted_cell_one !== -1) {
+    } else if (key === "[" && this.highlighted_cell_one !== -1) {
       // cycle highlight to prev label
       this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
           1, maxLabelsMap.get(this.feature));
@@ -241,7 +241,7 @@ class Mode {
         segLoaded = false;
         preCompAdjust();
       }
-    } else if (key === "=" && this.highlighted_cell_one !== -1) {
+    } else if (key === "]" && this.highlighted_cell_one !== -1) {
       // cycle highlight to next label
       this.highlighted_cell_one = this.increment_value(this.highlighted_cell_one,
           1, maxLabelsMap.get(this.feature));
@@ -274,7 +274,7 @@ class Mode {
       this.action = "delete";
       this.prompt = "delete label " + this.info.label + " in frame " + this.info.frame + "? " + answer;
       render_info_display();
-    } else if (key === "-") {
+    } else if (key === "[") {
       // cycle highlight to prev label
       this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
           1, maxLabelsMap.get(this.feature));
@@ -286,7 +286,7 @@ class Mode {
         segLoaded = false;
         preCompAdjust();
       }
-    } else if (key === "=") {
+    } else if (key === "]") {
       // cycle highlight to next label
       this.highlighted_cell_one = this.increment_value(this.highlighted_cell_one,
           1, maxLabelsMap.get(this.feature));

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1197,7 +1197,7 @@ function handle_mouseup() {
 function prepare_canvas() {
   // bind click on canvas
   $('#canvas').click(function(evt) {
-    if (!edit_mode || mode.kind === Modes.prompt) {
+    if (!spacedown && (!edit_mode || mode.kind === Modes.prompt)) {
       mode.click(evt);
     }
   });

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -978,19 +978,23 @@ function load_file(file) {
 function setCanvasDimensions() {
   // calculate available space and how much to scale x and y to fill it
   // only thing that shares width is the info display on left
-  let availWidth = Math.floor(document.documentElement.clientWidth * 0.75);
+
+  let maxWidth = Math.floor(document.documentElement.clientWidth * 0.75);
 
   // leave space for navbar, instructions pane, and footer
-  let availHeight = Math.floor((document.documentElement.clientHeight -
+  let maxHeight = Math.floor((document.documentElement.clientHeight -
+      parseInt($("#container").css('marginTop')) -
+      parseInt($("#container").css('marginBottom')) -
       document.getElementsByClassName('footer-text')[0].clientHeight -
       document.getElementsByClassName('accordion')[0].clientHeight -
       document.getElementsByClassName('navbar')[0].clientHeight)*0.95);
 
-  let scaleX = Math.floor(availWidth/rawWidth);
-  let scaleY = Math.floor(availHeight/rawHeight);
+  let scaleX = maxWidth/rawWidth;
+  let scaleY = maxHeight/rawHeight;
 
-  // pick scale that accomodates both dimensions
-  scale = Math.max(1, Math.min(scaleX, scaleY));
+  // pick scale that accomodates both dimensions; can be less than 1
+  scale = Math.min(scaleX, scaleY);
+  // dimensions need to maintain aspect ratio for drawing purposes
   dimensions = [scale * rawDimensions[0], scale * rawDimensions[1]];
 
   zoom = 100;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -626,6 +626,9 @@ var Modes = Object.freeze({
 
 let rgb;
 
+let rawWidth;
+let rawHeight;
+
 var scale;
 const padding = 5;
 
@@ -804,7 +807,7 @@ function render_edit_image(ctx) {
 
   } else {
     ctx.clearRect(padding, padding, dimensions[0], dimensions[1]);
-    ctx.drawImage(postCompImg, padding, padding, dimensions[0], dimensions[1]);
+    ctx.drawImage(postCompImg, 0, 0, rawWidth, rawHeight, padding, padding, dimensions[0], dimensions[1]);
   }
 
   // draw brushview on top of cells/annotations
@@ -869,6 +872,10 @@ function load_file(file) {
       feature_max = payload.feature_max;
       channel_max = payload.channel_max;
       rawDimensions = payload.dimensions;
+
+      rawWidth = rawDimensions[0];
+      rawHeight = rawDimensions[1];
+
       setCanvasDimensions();
 
       tracks = payload.tracks; //tracks payload is dict
@@ -906,8 +913,8 @@ function setCanvasDimensions() {
       document.getElementsByClassName('accordion')[0].clientHeight -
       document.getElementsByClassName('navbar')[0].clientHeight)*0.95);
 
-  let scaleX = Math.floor(availWidth/rawDimensions[0]);
-  let scaleY = Math.floor(availHeight/rawDimensions[1]);
+  let scaleX = Math.floor(availWidth/rawWidth);
+  let scaleY = Math.floor(availHeight/rawHeight);
 
   // pick scale that accomodates both dimensions
   scale = Math.max(1, Math.min(scaleX, scaleY));
@@ -916,8 +923,8 @@ function setCanvasDimensions() {
   // set canvases size according to scale
   $('#canvas').get(0).width = dimensions[0] + 2*padding;
   $('#canvas').get(0).height = dimensions[1] + 2*padding;
-  $('#hidden_seg_canvas').get(0).width = dimensions[0];
-  $('#hidden_seg_canvas').get(0).height = dimensions[1];
+  $('#hidden_seg_canvas').get(0).width = rawWidth;
+  $('#hidden_seg_canvas').get(0).height = rawHeight;
 }
 
 // adjust current_contrast upon mouse scroll

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -885,8 +885,8 @@ function load_file(file) {
       max_frames = payload.max_frames;
       feature_max = payload.feature_max;
       channel_max = payload.channel_max;
-      scale = 2;
-      dimensions = [scale * payload.dimensions[0], scale * payload.dimensions[1]];
+      rawDimensions = payload.dimensions;
+      setCanvasDimensions();
 
       tracks = payload.tracks; //tracks payload is dict
 
@@ -907,13 +907,27 @@ function load_file(file) {
       current_contrast = contrastMap.get(0);
 
       project_id = payload.project_id;
-      $('#canvas').get(0).width = dimensions[0] + 2*padding;
-      $('#canvas').get(0).height = dimensions[1] + 2*padding;
-      $('#hidden_seg_canvas').get(0).width = dimensions[0];
-      $('#hidden_seg_canvas').get(0).height = dimensions[1];
     },
     async: false
   });
+}
+
+function setCanvasDimensions() {
+  // calculate available space and how much to scale x and y to fill it
+  let availWidth = Math.floor(document.documentElement.clientWidth * 0.6);
+  let availHeight = Math.floor(document.documentElement.clientHeight * 0.8);
+  let scaleX = Math.floor(availWidth/rawDimensions[0]);
+  let scaleY = Math.floor(availHeight/rawDimensions[1]);
+
+  // pick scale that accomodates both dimensions
+  scale = Math.max(1, Math.min(scaleX, scaleY));
+  dimensions = [scale * rawDimensions[0], scale * rawDimensions[1]];
+
+  // set canvases size according to scale
+  $('#canvas').get(0).width = dimensions[0] + 2*padding;
+  $('#canvas').get(0).height = dimensions[1] + 2*padding;
+  $('#hidden_seg_canvas').get(0).width = dimensions[0];
+  $('#hidden_seg_canvas').get(0).height = dimensions[1];
 }
 
 // adjust current_contrast upon mouse scroll

--- a/browser/templates/form.html
+++ b/browser/templates/form.html
@@ -32,8 +32,8 @@
                 </h5>
                 <p>The .trk files allow you to annotate RAW264 cells across time-lapse frames while preserving relationship information.</p>
                 <p>
-                    The .npz files allow you to annotate different types of data. test.npz is an example of organoid annotation across z-stack frames. test2.npz is an example of untracked HeLa cytoplasm in a time-lapse movie (45 frames). test3.npz is another of untracked and
-                    uncorrected HeLa cytoplasm, but is only 5 frames.
+                    The .npz files allow you to annotate different types of data. test.npz is an example of organoid annotation across z-stack frames. test2.npz is a 3D example of nuclei in tissue. test3.npz is an example of untracked and
+                    uncorrected HeLa cytoplasm across time.
                 </p>
             </div>
             <form id="caliban-form" method="POST" action="{{ url_for('caliban.tool') }}">
@@ -42,10 +42,10 @@
                 <option value="RAW264_S0_Batch02.trk">RAW264_S0_Batch02.trk </option>
                 <option value="RAW264_S0_Batch05.trk">RAW264_S0_Batch05.trk</option>
                 <option value="RAW264_S0_Batch06.trk">RAW264_S0_Batch06.trk</option>
-                <!-- zstack test npz -->
+                <!-- zstack test npzs -->
                 <option value="test.npz">test.npz</option>
-                <!-- untracked cytoplasm movie test npz -->
-                <option value="HeLa-S3_cyto_movie_s2b05_all_channels.npz">test2.npz</option>
+                <option value="mouse_s1_uncorrected_fullsize_all_channels_x_05_y_03_save_version_0.npz">test2.npz</option>
+                <!-- uncorrected cytoplasm movie test npz -->
                 <option value="HeLa_movie_s0_uncorrected_fullsize_all_channels_x_00_y_01_frames_5-9.npz">test3.npz</option>
 
               </select>

--- a/browser/templates/index_zstack.html
+++ b/browser/templates/index_zstack.html
@@ -42,6 +42,7 @@
             <tr height="50%" valign="top"><td>frame: </td><td id="frame"></td></tr>
             <tr><td>channel: </td><td id="channel"></td></tr>
             <tr><td>feature: </td><td id="feature"></td></tr>
+            <tr><td>zoom: </td><td id="zoom"></td></tr>
             <tr><td>highlight cells: </td><td id="highlight"></td></tr>
             <tr><td>highlighted cells: </td><td id="currently_highlighted"></td></tr>
             <tr><td>edit mode: </td><td id="edit_mode"></td></tr>

--- a/browser/templates/index_zstack.html
+++ b/browser/templates/index_zstack.html
@@ -43,6 +43,8 @@
             <tr><td>channel: </td><td id="channel"></td></tr>
             <tr><td>feature: </td><td id="feature"></td></tr>
             <tr><td>zoom: </td><td id="zoom"></td></tr>
+            <tr><td>viewing (x): </td><td id="displayedX"></td></tr>
+            <tr><td>viewing (y): </td><td id="displayedY"></td></tr>
             <tr><td>highlight cells: </td><td id="highlight"></td></tr>
             <tr><td>highlighted cells: </td><td id="currently_highlighted"></td></tr>
             <tr><td>edit mode: </td><td id="edit_mode"></td></tr>

--- a/browser/templates/index_zstack.html
+++ b/browser/templates/index_zstack.html
@@ -67,6 +67,7 @@
         </tr>
       </table>
     </div>
+  {% include "footer.html" %}
 <!-- START CALIBAN FUNCTION CALL -->
   <script>
     function upload() {
@@ -81,6 +82,5 @@
   </script>
   <script type="text/javascript" src="{{ url_for('static', filename='js/infopane.js') }}"></script>
 <!-- END CALIBAN FUNCTION CALL -->
-  {% include "footer.html" %}
   </body>
 </html>

--- a/browser/templates/index_zstack.html
+++ b/browser/templates/index_zstack.html
@@ -26,46 +26,44 @@
     {% endif %}
     <canvas width=600 height=400 id="hidden_seg_canvas"></canvas>
     <div id="container">
-      <table id="maintable">
-        <tr>
-          <td id="logcol">
+      <table id="infotable">
+        <td id="logcol">
 
-            <h1>Z-Stack Tool</h1>
-            <p>Filename will be given after submit button is pressed.</p>
+          <h1>Z-Stack Tool</h1>
+          <p>Filename will be given after submit button is pressed.</p>
 
-            <p id="submit" onclick="upload() ">
-              <strong>CLICK HERE TO SUBMIT</strong>
-            </p>
+          <p id="submit" onclick="upload() ">
+            <strong>CLICK HERE TO SUBMIT</strong>
+          </p>
 
-            <p id="give_filename" ></p>
+          <p id="give_filename" ></p>
 
-            <table id="log">
-              <tr height="50%" valign="top"><td>frame: </td><td id="frame"></td></tr>
-              <tr><td>channel: </td><td id="channel"></td></tr>
-              <tr><td>feature: </td><td id="feature"></td></tr>
-              <tr><td>highlight cells: </td><td id="highlight"></td></tr>
-              <tr><td>highlighted cells: </td><td id="currently_highlighted"></td></tr>
-              <tr><td>edit mode: </td><td id="edit_mode"></td></tr>
-              <tr id='edit_brush_row'>
-                <td>brush size: </td><td id="edit_brush"></td>
-              </tr>
-              <tr id='edit_label_row'>
-                <td>editing label: </td><td id="edit_label"></td>
-              </tr>
-              <tr id='edit_erase_row'>
-                <td>eraser: </td><td id="edit_erase"></td>
-              </tr>
-              <tr><td>label:</td><td id="label"></td></tr>
-              <tr><td>slices:</td><td><div id="slices"></div></td></tr>
-              <tr><td>state:</td><td id="mode"></td></tr>
-            </table>
-          </td>
-          <td id="canvascol">
-            <canvas width=600 height=400 id="canvas"></canvas>
-            <div id="output"></div>
-          </td>
-        </tr>
+          <table id="log">
+            <tr height="50%" valign="top"><td>frame: </td><td id="frame"></td></tr>
+            <tr><td>channel: </td><td id="channel"></td></tr>
+            <tr><td>feature: </td><td id="feature"></td></tr>
+            <tr><td>highlight cells: </td><td id="highlight"></td></tr>
+            <tr><td>highlighted cells: </td><td id="currently_highlighted"></td></tr>
+            <tr><td>edit mode: </td><td id="edit_mode"></td></tr>
+            <tr id='edit_brush_row'>
+              <td>brush size: </td><td id="edit_brush"></td>
+            </tr>
+            <tr id='edit_label_row'>
+              <td>editing label: </td><td id="edit_label"></td>
+            </tr>
+            <tr id='edit_erase_row'>
+              <td>eraser: </td><td id="edit_erase"></td>
+            </tr>
+            <tr><td>label:</td><td id="label"></td></tr>
+            <tr><td>slices:</td><td><div id="slices"></div></td></tr>
+            <tr><td>state:</td><td id="mode"></td></tr>
+          </table>
+        </td>
       </table>
+      <div id="canvascol">
+        <canvas width=600 height=400 id="canvas"></canvas>
+        <div id="output"></div>
+      </div>
     </div>
   {% include "footer.html" %}
 <!-- START CALIBAN FUNCTION CALL -->

--- a/browser/templates/infopane.html
+++ b/browser/templates/infopane.html
@@ -12,7 +12,11 @@
 
     <p><strong>Mouse</strong> over a cell mask to see cell label and lineage information.</p>
 
+    <p><strong>Spacebar + click and drag</strong> to pan across the viewed image.</p>
+
     <p><strong>Scroll Wheel</strong> | In raw image or edit mode, scroll up/down to change the contrast of the image. Hold down the shift key while scrolling to change the brightness. (These values can be reset by pressing 0.)&nbsp;</p>
+
+    <p><strong>Alt+Scroll Wheel</strong> or <strong>-</strong> and <strong>=</strong> | Zoom in and out on the image.</p>
 
     <p><strong>0 (zero)</strong> | Reset the brightness and contrast settings, if viewing the raw image or in pixel-editing mode.&nbsp;</p>
 
@@ -82,9 +86,9 @@
 
     <p><em>To change the value of the brush:</em></p>
 
-    <p><strong>-</strong> | Decrease the value of the brush</p>
+    <p><strong>[</strong> | Decrease the value of the brush</p>
 
-    <p><strong>=</strong> | Increase the value of the brush</p>
+    <p><strong>]</strong> | Increase the value of the brush</p>
 
     <p><strong>n</strong> | Set brush to an unused value</p>
 

--- a/browser/templates/infopane_abridged.html
+++ b/browser/templates/infopane_abridged.html
@@ -12,7 +12,11 @@
 
     <p><strong>Mouse</strong> over a cell mask to see cell label and lineage information.</p>
 
+    <p><strong>Spacebar + click and drag</strong> to pan across the viewed image.</p>
+
     <p><strong>Scroll Wheel</strong> | In raw image or edit mode, scroll up/down to change the contrast of the image. Hold down the shift key while scrolling to change the brightness. (These values can be reset by pressing 0.)&nbsp;</p>
+
+    <p><strong>Alt+Scroll Wheel</strong> or <strong>-</strong> and <strong>=</strong> | Zoom in and out on the image.</p>
 
     <p><strong>0 (zero)</strong> | Reset the brightness and contrast settings, if viewing the raw image or in pixel-editing mode.&nbsp;</p>
 


### PR DESCRIPTION
- change how images are stored and displayed
  - image loading triggers a cascade of image modification and storage to Image objects
  - changes to certain variables (eg, image contrast) trigger appropriate parts of the image modification cascade
  - image cascade prevents image flickering (new images are not rendered until all images in cascade are loaded and ready to display), allows for scaling, panning, and zooming, and improves image processing (images are processed once, instead of continually while being displayed; original size images are processed and scaled during display, instead of processing scaled images)
  - addresses #140 
- displayed canvas size scales appropriately to match available space in window
  - images that are too large for space are scaled to be smaller while maintaining aspect ratio
  - python object is agnostic to scaling factor, all image coordinate conversion handled in frontend
  - some html and css changed to reduce awkward blank areas
  - addresses #51, #131 
- pan and zoom on canvas
  - alt+scroll or -/= keys to zoom, spacebar + click&drag to pan across canvas
  - zoom and current displayed indices of image displayed in sidebar
  - canvas border visually indicates if at edge of image (white) or not (black) (no red "label out of sight" indicator implemented)
  - addresses #41 
- listen for mouseup event in document, not just canvas for smoother behavior (drawing, thresholding, panning)

Waiting to close linked issues until they are also fixed for trk files.