### PR TITLE
Add logger statements to most routes.

### DIFF
--- a/browser/application.py
+++ b/browser/application.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import logging
+from logging.config import dictConfig
+
 from flask import Flask
+from flask.logging import default_handler
 
 import config
 from blueprints import bp
@@ -19,6 +23,29 @@ class ReverseProxied(object):
         if scheme:
             environ['wsgi.url_scheme'] = scheme
         return self.app(environ, start_response)
+
+
+def configure_logging():
+    """Set up logging format and instantiate loggers"""
+    # Set up logging
+    dictConfig({
+        'version': 1,
+        'formatters': {'default': {
+            'format': '[%(asctime)s]:[%(levelname)s]:[%(name)s]: %(message)s',
+        }},
+        'handlers': {'wsgi': {
+            'class': 'logging.StreamHandler',
+            'stream': 'ext://flask.logging.wsgi_errors_stream',
+            'formatter': 'default'
+        }},
+        'root': {
+            'level': 'INFO',
+            'handlers': ['wsgi']
+        }
+    })
+
+    # set up 3rd party logging.
+    logging.getLogger('sqlalchemy').addHandler(default_handler)
 
 
 def create_app():
@@ -44,4 +71,5 @@ def create_app():
 application = create_app()  # pylint: disable=C0103
 
 if __name__ == '__main__':
+    configure_logging()
     application.run('0.0.0.0', port=config.PORT, debug=config.DEBUG)

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -28,7 +28,7 @@ bp = Blueprint('caliban', __name__)  # pylint: disable=C0103
 @bp.route('/health')
 def health():
     '''Returns success if the application is ready.'''
-    return 'success'
+    return jsonify({'message': 'success'})
 
 
 @bp.route('/upload_file/<int:project_id>', methods=['GET', 'POST'])

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -8,6 +8,7 @@ import json
 import os
 import pickle
 import re
+import timeit
 import traceback
 
 from flask import Blueprint

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -53,8 +53,8 @@ def upload_file(project_id):
     # add "finished" timestamp and null out state longblob
     Project.finish_project(project)
 
-    current_app.logger.debug('Finished project in %s s.',
-                             timeit.default_timer() - start)
+    current_app.logger.debug('Finished project "%s" in %s s.',
+                             project_id, timeit.default_timer() - start)
 
     return redirect('/')
 
@@ -107,8 +107,9 @@ def action(project_id, action_type, frame):
     else:
         img_payload = False
 
-    current_app.logger.debug('Action "%s" finished in %s s.',
-                             action_type, timeit.default_timer() - start)
+    current_app.logger.debug('Action "%s" for project "%s" finished in %s s.',
+                             action_type, project_id,
+                             timeit.default_timer() - start)
 
     return jsonify({'tracks': tracks, 'imgs': img_payload})
 
@@ -142,8 +143,8 @@ def get_frame(frame, project_id):
         'seg_arr': edit_arr.tolist()
     }
 
-    current_app.logger.debug('Got frame %s in %s s.',
-                             frame, timeit.default_timer() - start)
+    current_app.logger.debug('Got frame %s of project "%s" in %s s.',
+                             frame, project_id, timeit.default_timer() - start)
 
     return jsonify(payload)
 
@@ -170,8 +171,8 @@ def load(filename):
         # Initate TrackReview object and entry in database
         track_review = TrackReview(filename, input_bucket, output_bucket, full_path)
         project = Project.create_project(filename, track_review, subfolders)
-        current_app.logger.debug('Loaded trk file in %s s.',
-                                 timeit.default_timer() - start)
+        current_app.logger.debug('Loaded trk file "%s" in %s s.',
+                                 filename, timeit.default_timer() - start)
         # Send attributes to .js file
         return jsonify({
             'max_frames': track_review.max_frames,
@@ -188,8 +189,8 @@ def load(filename):
         # Initate ZStackReview object and entry in database
         zstack_review = ZStackReview(filename, input_bucket, output_bucket, full_path, rgb)
         project = Project.create_project(filename, zstack_review, subfolders)
-        current_app.logger.debug('Loaded npz file in %s s.',
-                                 timeit.default_timer() - start)
+        current_app.logger.debug('Loaded npz file "%s" in %s s.',
+                                 filename, timeit.default_timer() - start)
         # Send attributes to .js file
         return jsonify({
             'max_frames': zstack_review.max_frames,

--- a/browser/templates/index.html
+++ b/browser/templates/index.html
@@ -13,8 +13,8 @@
     <p>
       The .npz files allow you to annotate different types of data.
       test.npz is an example of organoid annotation across z-stack frames.
-      test2.npz is an example of untracked HeLa cytoplasm in a time-lapse movie (45 frames).
-      test3.npz is another of untracked and uncorrected HeLa cytoplasm, but is only 5 frames.
+      test2.npz is a 3D example of nuclei in tissue.
+      test3.npz is an example of untracked and uncorrected HeLa cytoplasm across time.
     </p>
   </div>
 


### PR DESCRIPTION
Add a logger statement and a timer to help identify the longest-taking functions.

Also:
- Minor updates to docstrings.
- Removed redundant `str()` call when creating the template name.
- Updated description of NPZ files on landing page.