### PR TITLE
skip rescaling for empty channels

### DIFF
--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -5061,7 +5061,11 @@ class RGBNpz(CalibanWindow):
         self.rescaled = np.zeros(self.raw.shape, dtype = 'uint8')
         # this approach allows noise through
         for channel in range(min(6, self.channel_max)):
-            self.rescaled[:,:,channel] = self.rescale_95(self.raw[:,:,channel])
+            if np.sum(self.raw[:,:,channel]) == 0:
+                # don't empty channels
+                pass
+            else:
+                self.rescaled[:,:,channel] = self.rescale_95(self.raw[:,:,channel])
 
     def reduce_to_RGB(self):
         '''


### PR DESCRIPTION
Modified rescaling function to pass over channels that are completely empty to avoid 0 indexing errors. 

We previously padded empty channels with mostly blank images, I switched fully blank images so that in the future we can have logic that treats fully empty channels differently. 