### PR TITLE
Browser/fix/rgb rendering

### DIFF
--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -41,6 +41,8 @@ class ZStackReview:
         self.feature_max = self.annotated.shape[-1]
         self.channel = 0
 
+        self.current_frame = 0
+
         if self.rgb:
             # possible differences between single channel and rgb displays
             self.dims = len(self.raw.shape)
@@ -62,8 +64,6 @@ class ZStackReview:
         # analogous to .trk lineage but do not need relationships between cells included
         self.cell_ids = {}
         self.cell_info = {}
-
-        self.current_frame = 0
 
         for feature in range(self.feature_max):
             self.create_cell_info(feature)

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -123,7 +123,7 @@ class ZStackReview:
         '''
         self.rescaled = np.zeros((self.height, self.width, self.rgb_channels), dtype='uint8')
         # this approach allows noise through
-        for channel in range(min(5, self.rgb_channels)):
+        for channel in range(min(6, self.rgb_channels)):
             try:
                 self.rescaled[:, :, channel] = self.rescale_95(self.raw[0, :, :, channel])
 
@@ -142,7 +142,7 @@ class ZStackReview:
         self.rgb_img = np.zeros((self.height, self.width, 3), dtype='uint16')
 
         # for each of the channels that we have
-        for c in range(min(5, self.rgb_channels)):
+        for c in range(min(6, self.rgb_channels)):
             # straightforward RGB -> RGB
             if c < 3:
                 self.rgb_img[:, :, c] = (self.rescaled[:, :, c]).astype('uint16')

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -124,12 +124,12 @@ class ZStackReview:
         self.rescaled = np.zeros((self.height, self.width, self.rgb_channels), dtype='uint8')
         # this approach allows noise through
         for channel in range(min(6, self.rgb_channels)):
-            try:
-                self.rescaled[:, :, channel] = self.rescale_95(self.raw[0, :, :, channel])
-
-            # if the channel is totally empty, rescaling will fail
-            except IndexError:
-                self.rescaled[:, :, channel] = np.copy(self.raw[0, :, :, channel])
+            raw_channel = self.raw[self.current_frame, :, :, channel]
+            if np.sum(raw_channel) == 0:
+                # don't rescale empty channels
+                pass
+            else:
+                self.rescaled[:, :, channel] = self.rescale_95(raw_channel)
 
     def reduce_to_RGB(self):
         '''

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -124,7 +124,12 @@ class ZStackReview:
         self.rescaled = np.zeros((self.height, self.width, self.rgb_channels), dtype='uint8')
         # this approach allows noise through
         for channel in range(min(5, self.rgb_channels)):
-            self.rescaled[:, :, channel] = self.rescale_95(self.raw[0, :, :, channel])
+            try:
+                self.rescaled[:, :, channel] = self.rescale_95(self.raw[0, :, :, channel])
+
+            # if the channel is totally empty, rescaling will fail
+            except IndexError:
+                self.rescaled[:, :, channel] = np.copy(self.raw[0, :, :, channel])
 
     def reduce_to_RGB(self):
         '''


### PR DESCRIPTION
Add logic to channel rescaling to prevent rescaling of completely empty channels. Fixes bug observed by crowdsource annotators. Also fixes minor bug that keeps yellow channel from being incorporated into displayed image.