### PR TITLE
Use PIL to create PNGs if not using a cmap.

### DIFF
--- a/browser/imgutils.py
+++ b/browser/imgutils.py
@@ -1,13 +1,20 @@
+"""Utilities for handling images"""
 import io
+
 import matplotlib.pyplot as plt
+from PIL import Image
 
 
-def pngify(imgarr, vmin, vmax, cmap):
+def pngify(imgarr, vmin, vmax, cmap=None):
     out = io.BytesIO()
-    plt.imsave(out, imgarr,
-               vmin=vmin,
-               vmax=vmax,
-               cmap=cmap,
-               format="png")
+    if cmap is None:
+        img = Image.fromarray(imgarr)
+        img.save(out, format="png")
+    else:
+        plt.imsave(out, imgarr,
+                   vmin=vmin,
+                   vmax=vmax,
+                   cmap=cmap,
+                   format="png")
     out.seek(0)
     return out

--- a/browser/imgutils.py
+++ b/browser/imgutils.py
@@ -2,19 +2,21 @@
 import io
 
 import matplotlib.pyplot as plt
+from matplotlib.colors import Normalize
+
 from PIL import Image
 
 
 def pngify(imgarr, vmin, vmax, cmap=None):
     out = io.BytesIO()
-    if cmap is None:
-        img = Image.fromarray(imgarr)
-        img.save(out, format="png")
-    else:
-        plt.imsave(out, imgarr,
-                   vmin=vmin,
-                   vmax=vmax,
-                   cmap=cmap,
-                   format="png")
+
+    if cmap:
+        cmap = plt.get_cmap(cmap)
+        imgarr = Normalize(vmin=vmin, vmax=vmax)(imgarr)
+        # apply the colormap
+        imgarr = cmap(imgarr, bytes=True)
+
+    img = Image.fromarray(imgarr)
+    img.save(out, format="png")
     out.seek(0)
     return out

--- a/browser/requirements.txt
+++ b/browser/requirements.txt
@@ -1,8 +1,8 @@
 flask==1.1.1
 flask-sqlalchemy==2.4.1
 matplotlib==3.0.3
-mysqlclient==1.4.5
 numpy==1.16.4
 boto3==1.9.182
 scikit-image==0.15.0
 python-decouple==3.1
+pillow==6.2.2

--- a/browser/requirements.txt
+++ b/browser/requirements.txt
@@ -1,6 +1,7 @@
 flask==1.1.1
 flask-sqlalchemy==2.4.1
 matplotlib==3.0.3
+mysqlclient==1.4.5
 numpy==1.16.4
 boto3==1.9.182
 scikit-image==0.15.0


### PR DESCRIPTION
`PIL` is much faster than `matplotlib`. I could not find a way to replace the `matplotlib` functions while still using a color map, but if no cmap is provided, we can use PIL to speed it up significantly.

Related to #68 and #142 