### PR TITLE
Don't need to return raw data on action requests.

### DIFF
--- a/browser/.gitignore
+++ b/browser/.gitignore
@@ -6,3 +6,5 @@
 
 # python-decouple
 .env
+
+node_modules/

--- a/browser/.gitignore
+++ b/browser/.gitignore
@@ -6,5 +6,3 @@
 
 # python-decouple
 .env
-
-node_modules/

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -95,13 +95,13 @@ def action(project_id, action_type, frame):
 
     if frames_changed:
         img = state.get_frame(frame, raw=False)
-        raw = state.get_frame(frame, raw=True)
+        # raw = state.get_frame(frame, raw=True)
         edit_arr = state.get_array(frame)
 
         encode = lambda x: base64.encodebytes(x.read()).decode()
 
         img_payload = {
-            'raw': f'data:image/png;base64,{encode(raw)}',
+            # 'raw': f'data:image/png;base64,{encode(raw)}',
             'segmented': f'data:image/png;base64,{encode(img)}',
             'seg_arr': edit_arr.tolist()
         }

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -80,9 +80,11 @@ def action(project_id, action_type, frame):
         # Perform edit operation on the data file
         state.action(action_type, info)
         frames_changed = state.frames_changed
+        x_changed = state._x_changed
+        y_changed = state._y_changed
         info_changed = state.info_changed
 
-        state.frames_changed = state.info_changed = False
+        state._x_changed = state._y_changed = state.info_changed = False
 
         # Update object in local database
         Project.update_project(project, state)
@@ -94,17 +96,17 @@ def action(project_id, action_type, frame):
     tracks = state.readable_tracks if info_changed else False
 
     if frames_changed:
-        img = state.get_frame(frame, raw=False)
-        # raw = state.get_frame(frame, raw=True)
-        edit_arr = state.get_array(frame)
-
         encode = lambda x: base64.encodebytes(x.read()).decode()
+        edit_arr = state.get_array(frame)
+        img_payload = {'seg_arr': edit_arr.tolist()}
 
-        img_payload = {
-            # 'raw': f'data:image/png;base64,{encode(raw)}',
-            'segmented': f'data:image/png;base64,{encode(img)}',
-            'seg_arr': edit_arr.tolist()
-        }
+        if x_changed:
+            raw = state.get_frame(frame, raw=True)
+            img_payload['raw'] = f'data:image/png;base64,{encode(raw)}'
+        if y_changed:
+            img = state.get_frame(frame, raw=False)
+            img_payload['segmented'] = f'data:image/png;base64,{encode(img)}'
+
     else:
         img_payload = False
 

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -79,7 +79,7 @@ def action(project_id, action_type, frame):
         state = pickle.loads(project.state)
         # Perform edit operation on the data file
         state.action(action_type, info)
-        frames_changed = state.frames_changed
+
         x_changed = state._x_changed
         y_changed = state._y_changed
         info_changed = state.info_changed
@@ -95,7 +95,7 @@ def action(project_id, action_type, frame):
 
     tracks = state.readable_tracks if info_changed else False
 
-    if frames_changed:
+    if x_changed or y_changed:
         encode = lambda x: base64.encodebytes(x.read()).decode()
         img_payload = {}
 

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -98,7 +98,7 @@ def action(project_id, action_type, frame):
     if frames_changed:
         encode = lambda x: base64.encodebytes(x.read()).decode()
         edit_arr = state.get_array(frame)
-        img_payload = {'seg_arr': edit_arr.tolist()}
+        img_payload = {}
 
         if x_changed:
             raw = state.get_frame(frame, raw=True)
@@ -106,6 +106,7 @@ def action(project_id, action_type, frame):
         if y_changed:
             img = state.get_frame(frame, raw=False)
             img_payload['segmented'] = f'data:image/png;base64,{encode(img)}'
+            img_payload['seg_arr'] = edit_arr.tolist()
 
     else:
         img_payload = False

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -97,7 +97,6 @@ def action(project_id, action_type, frame):
 
     if frames_changed:
         encode = lambda x: base64.encodebytes(x.read()).decode()
-        edit_arr = state.get_array(frame)
         img_payload = {}
 
         if x_changed:
@@ -106,6 +105,7 @@ def action(project_id, action_type, frame):
         if y_changed:
             img = state.get_frame(frame, raw=False)
             img_payload['segmented'] = f'data:image/png;base64,{encode(img)}'
+            edit_arr = state.get_array(frame)
             img_payload['seg_arr'] = edit_arr.tolist()
 
     else:

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -84,10 +84,6 @@ class ZStackReview:
         self._y_changed = False
         self.info_changed = False
 
-    @property
-    def frames_changed(self):
-        return self._x_changed or self._y_changed
-
     def _get_s3_client(self):
         return boto3.client(
             's3',
@@ -752,10 +748,6 @@ class TrackReview:
         self._y_changed = False
         self.info_changed = False
 
-    @property
-    def frames_changed(self):
-        return self._x_changed or self._y_changed
-
     def _get_s3_client(self):
         return boto3.client(
             's3',
@@ -922,7 +914,7 @@ class TrackReview:
         img_trimmed = np.where(np.logical_and(np.invert(contig_cell), img_ann == label), 0, img_ann)
 
         comparison = np.where(img_trimmed != img_ann)
-        self._y_frames = np.any(comparison)
+        self._y_changed = np.any(comparison)
 
         self.tracked[frame, :, :, 0] = img_trimmed
 

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -80,8 +80,13 @@ class ZStackReview:
         self.color_map = plt.get_cmap('viridis')
         self.color_map.set_bad('black')
 
-        self.frames_changed = False
+        self._x_changed = False
+        self._y_changed = False
         self.info_changed = False
+
+    @property
+    def frames_changed(self):
+        return self._x_changed or self._y_changed
 
     def _get_s3_client(self):
         return boto3.client(
@@ -284,11 +289,11 @@ class ZStackReview:
 
     def action_change_channel(self, channel):
         self.channel = channel
-        self.frames_changed = True
+        self._x_changed = True
 
     def action_change_feature(self, feature):
         self.feature = feature
-        self.frames_changed = True
+        self._y_changed = True
 
     def action_handle_draw(self, trace, target_value, brush_value, brush_size, erase, frame):
 
@@ -324,7 +329,7 @@ class ZStackReview:
 
         # check for image change, in case pixels changed but no new or del cell
         comparison = np.where(annotated != self.annotated[frame, :, :, self.feature])
-        self.frames_changed = np.any(comparison)
+        self._y_changed = np.any(comparison)
         # if info changed, self.info_changed set to true with info helper functions
 
         self.annotated[frame, :, :, self.feature] = annotated
@@ -399,7 +404,7 @@ class ZStackReview:
 
         # check if image changed
         comparison = np.where(img_trimmed != img_ann)
-        self.frames_changed = np.any(comparison)
+        self._y_changed = np.any(comparison)
         # this action should never change the cell info
 
         self.annotated[frame, :, :, self.feature] = img_trimmed
@@ -419,7 +424,7 @@ class ZStackReview:
         self.annotated[frame, :, :, self.feature] = filled_img_ann
 
         # never changes info but always changes annotation
-        self.frames_changed = True
+        self._y_changed = True
 
     def action_new_single_cell(self, label, frame):
         """
@@ -504,7 +509,7 @@ class ZStackReview:
 
         self.annotated[frame, :, :, self.feature] = ann_img
 
-        self.frames_changed = self.info_changed = True
+        self._y_changed = self.info_changed = True
 
     def action_swap_all_frame(self, label_1, label_2):
 
@@ -521,7 +526,7 @@ class ZStackReview:
         self.cell_info[self.feature][label_1].update({'frames': cell_info_2['frames']})
         self.cell_info[self.feature][label_2].update({'frames': cell_info_1['frames']})
 
-        self.frames_changed = self.info_changed = True
+        self._y_changed = self.info_changed = True
 
     def action_watershed(self, label, frame, x1_location, y1_location, x2_location, y2_location):
         # Pull the label that is being split and find a new valid label
@@ -597,10 +602,10 @@ class ZStackReview:
 
             # check if image changed
             comparison = np.where(next_img != updated_slice)
-            self.frames_changed = np.any(comparison)
+            self._y_changed = np.any(comparison)
 
             # if the image changed, update self.annotated and remake cell info
-            if self.frames_changed:
+            if self._y_changed:
                 self.annotated[current_slice, :, :, int(self.feature)] = updated_slice
                 self.create_cell_info(feature=int(self.feature))
 
@@ -620,7 +625,7 @@ class ZStackReview:
             self.annotated[zslice + 1, :, :, self.feature] = predicted_next
 
         # remake cell_info dict based on new annotations
-        self.frames_changed = True
+        self._y_changed = True
         self.create_cell_info(feature=self.feature)
 
     def action_save_zstack(self):
@@ -655,7 +660,7 @@ class ZStackReview:
             self.cell_ids[feature] = np.append(self.cell_ids[feature], add_label)
 
         # if adding cell, frames and info have necessarily changed
-        self.frames_changed = self.info_changed = True
+        self._y_changed = self.info_changed = True
 
     def del_cell_info(self, feature, del_label, frame):
         '''
@@ -675,7 +680,7 @@ class ZStackReview:
             self.cell_ids[feature] = np.delete(ids, np.where(ids == np.int64(del_label)))
 
         # if deleting cell, frames and info have necessarily changed
-        self.frames_changed = self.info_changed = True
+        self._y_changed = self.info_changed = True
 
     def create_cell_info(self, feature):
         '''
@@ -743,8 +748,13 @@ class TrackReview:
 
         self.current_frame = 0
 
-        self.frames_changed = False
+        self._x_changed = False
+        self._y_changed = False
         self.info_changed = False
+
+    @property
+    def frames_changed(self):
+        return self._x_changed or self._y_changed
 
     def _get_s3_client(self):
         return boto3.client(
@@ -871,7 +881,7 @@ class TrackReview:
             self.add_cell_info(add_label=edit_value, frame=frame)
 
         comparison = np.where(annotated != self.tracked[frame])
-        self.frames_changed = np.any(comparison)
+        self._y_changed = np.any(comparison)
 
         self.tracked[frame] = annotated
 
@@ -912,7 +922,7 @@ class TrackReview:
         img_trimmed = np.where(np.logical_and(np.invert(contig_cell), img_ann == label), 0, img_ann)
 
         comparison = np.where(img_trimmed != img_ann)
-        self.frames_changed = np.any(comparison)
+        self._y_frames = np.any(comparison)
 
         self.tracked[frame, :, :, 0] = img_trimmed
 
@@ -931,7 +941,7 @@ class TrackReview:
         filled_img_ann = flood_fill(img_ann, hole_fill_seed, label, connectivity=1)
         self.tracked[frame, :, :, 0] = filled_img_ann
 
-        self.frames_changed = True
+        self._y_changed = True
 
     def action_new_single_cell(self, label, frame):
         """
@@ -988,7 +998,7 @@ class TrackReview:
             track_old["frame_div"] = None
             track_old["capped"] = True
 
-            self.frames_changed = self.info_changed = True
+            self._y_changed = self.info_changed = True
 
     def action_delete(self, label, frame):
         """
@@ -1055,7 +1065,7 @@ class TrackReview:
             except ValueError:
                 pass
 
-        self.frames_changed = self.info_changed = True
+        self._y_changed = self.info_changed = True
 
     def action_swap_single_frame(self, label_1, label_2, frame):
         '''swap the labels of two cells in one frame, but do not
@@ -1068,7 +1078,7 @@ class TrackReview:
 
         self.tracked[frame, :, :, 0] = ann_img
 
-        self.frames_changed = True
+        self._y_changed = True
 
     def action_swap_tracks(self, label_1, label_2):
         def relabel(old_label, new_label):
@@ -1092,7 +1102,7 @@ class TrackReview:
         relabel(label_2, label_1)
         relabel(-1, label_2)
 
-        self.frames_changed = self.info_changed = True
+        self._y_changed = self.info_changed = True
 
     def action_watershed(self, label, frame, x1_location, y1_location, x2_location, y2_location):
 
@@ -1214,7 +1224,7 @@ class TrackReview:
             self.tracks[add_label].update({'parent': None})
             self.tracks[add_label].update({'capped': False})
 
-        self.frames_changed = self.info_changed = True
+        self._y_changed = self.info_changed = True
 
     def del_cell_info(self, del_label, frame):
         '''
@@ -1238,7 +1248,7 @@ class TrackReview:
                 if track["parent"] == del_label:
                     track["parent"] = None
 
-        self.frames_changed = self.info_changed = True
+        self._y_changed = self.info_changed = True
 
 
 def consecutive(data, stepsize=1):

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -833,7 +833,9 @@ function action(action, info, frame = current_frame) {
         // array of arrays, contains annotation data for frame
         seg_array = payload.imgs.seg_arr;
         seg_image.src = payload.imgs.segmented;
-        raw_image.src = payload.imgs.raw;
+        if (payload.imgs.hasOwnProperty('raw')) {
+          raw_image.src = payload.imgs.raw;
+        }
       }
       if (payload.tracks) {
         tracks = payload.tracks;

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -831,8 +831,14 @@ function action(action, info, frame = current_frame) {
       if (payload.imgs) {
         // load new value of seg_array
         // array of arrays, contains annotation data for frame
-        seg_array = payload.imgs.seg_arr;
-        seg_image.src = payload.imgs.segmented;
+        if (payload.imgs.hasOwnProperty('seg_arr')) {
+          seg_arr = payload.imgs.seg_arr;
+        }
+
+        if (payload.imgs.hasOwnProperty('segmented')) {
+          seg_image.src = payload.imgs.segmented;
+        }
+
         if (payload.imgs.hasOwnProperty('raw')) {
           raw_image.src = payload.imgs.raw;
         }

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -832,7 +832,7 @@ function action(action, info, frame = current_frame) {
         // load new value of seg_array
         // array of arrays, contains annotation data for frame
         if (payload.imgs.hasOwnProperty('seg_arr')) {
-          seg_arr = payload.imgs.seg_arr;
+          seg_array = payload.imgs.seg_arr;
         }
 
         if (payload.imgs.hasOwnProperty('segmented')) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1296,9 +1296,6 @@ function action(action, info, frame = current_frame) {
         alert(payload.error);
       }
       if (payload.imgs) {
-        rawLoaded = false;
-        segLoaded = false;
-
         // load new value of seg_array
         // array of arrays, contains annotation data for frame
         if (payload.imgs.hasOwnProperty('seg_arr')) {
@@ -1308,15 +1305,11 @@ function action(action, info, frame = current_frame) {
         if (payload.imgs.hasOwnProperty('segmented')) {
           segLoaded = false;
           seg_image.src = payload.imgs.segmented;
-        } else {
-          segLoaded = true;
         }
 
         if (payload.imgs.hasOwnProperty('raw')) {
           rawLoaded = false;
           raw_image.src = payload.imgs.raw;
-        } else {
-          rawLoaded = true;
         }
       }
       if (payload.tracks) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1301,9 +1301,16 @@ function action(action, info, frame = current_frame) {
 
         // load new value of seg_array
         // array of arrays, contains annotation data for frame
-        seg_array = payload.imgs.seg_arr;
+        if (payload.imgs.hasOwnProperty('seg_arr')) {
+          seg_arr = payload.imgs.seg_arr;
+        }
 
-        seg_image.src = payload.imgs.segmented;
+        if (payload.imgs.hasOwnProperty('segmented')) {
+          segLoaded = false;
+          seg_image.src = payload.imgs.segmented;
+        } else {
+          segLoaded = true;
+        }
 
         if (payload.imgs.hasOwnProperty('raw')) {
           rawLoaded = false;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1304,7 +1304,13 @@ function action(action, info, frame = current_frame) {
         seg_array = payload.imgs.seg_arr;
 
         seg_image.src = payload.imgs.segmented;
-        raw_image.src = payload.imgs.raw;
+
+        if (payload.imgs.hasOwnProperty('raw')) {
+          rawLoaded = false;
+          raw_image.src = payload.imgs.raw;
+        } else {
+          rawLoaded = true;
+        }
       }
       if (payload.tracks) {
         tracks = payload.tracks;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1302,7 +1302,7 @@ function action(action, info, frame = current_frame) {
         // load new value of seg_array
         // array of arrays, contains annotation data for frame
         if (payload.imgs.hasOwnProperty('seg_arr')) {
-          seg_arr = payload.imgs.seg_arr;
+          seg_array = payload.imgs.seg_arr;
         }
 
         if (payload.imgs.hasOwnProperty('segmented')) {


### PR DESCRIPTION
This PR prevents the API from returning raw data on every action request, when actions only manipulate the annotations.  I've adapted the JS so that if the action _does_ include raw in the payload it will overwrite it currently, otherwise it just sets `rawLoaded = true`.

Are there any actions that will require an update to the raw image data?

Related to #68 and #142 