### PR TITLE
Save npzs with X and y

### DIFF
--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -627,6 +627,8 @@ class ZStackReview:
     def action_save_zstack(self):
         # save file to BytesIO object
         store_npz = io.BytesIO()
+
+        # X and y are array names by convention
         np.savez(store_npz, X=self.raw, y=self.annotated)
         store_npz.seek(0)
 

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -1405,13 +1405,17 @@ def load_npz(filename):
     data = io.BytesIO(filename)
     npz = np.load(data)
 
+    # standard nomenclature for image (X) and annotation (y)
     if 'y' in npz.files:
         raw_stack = npz['X']
         annotation_stack = npz['y']
 
+    # some files may have alternate names 'raw' and 'annotated'
     elif 'raw' in npz.files:
         raw_stack = npz['raw']
         annotation_stack = npz['annotated']
+
+    # if files are named something different, give it a try anyway
     else:
         raw_stack = npz[npz.files[0]]
         annotation_stack = npz[npz.files[1]]

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -627,7 +627,7 @@ class ZStackReview:
     def action_save_zstack(self):
         # save file to BytesIO object
         store_npz = io.BytesIO()
-        np.savez(store_npz, raw=self.raw, annotated=self.annotated)
+        np.savez(store_npz, X=self.raw, y=self.annotated)
         store_npz.seek(0)
 
         # store npz file object in bucket/subfolders (subfolders is full path)


### PR DESCRIPTION
Close #160. For historical reasons we may have npzs still floating around saved with variable names `raw` and `annotated` instead of `X` and `y`, so these npzs should still be loaded by caliban, but we have no particular reason not to save them as `X` and `y` going forward.