### PR TITLE
Hide labels, bugfixes

### DIFF
--- a/browser/static/js/adjust.js
+++ b/browser/static/js/adjust.js
@@ -138,8 +138,8 @@ function preCompAdjust() {
   preCompSeg.src = canvas.toDataURL();
 }
 
-// adjust raw further (if needed), composite annotations on top
-function compositeImages() {
+// adjust raw further, pre-compositing (use to draw when labels hidden)
+function preCompRawAdjust() {
   let canvas = document.getElementById('hidden_seg_canvas');
   let ctx = $('#hidden_seg_canvas').get(0).getContext('2d');
   ctx.imageSmoothingEnabled = false;
@@ -153,6 +153,17 @@ function compositeImages() {
     invert(rawData);
   }
   ctx.putImageData(rawData, 0, 0);
+
+  preCompRaw.src = canvas.toDataURL();
+}
+
+// composite annotations on top of adjusted raw image
+function compositeImages() {
+  let canvas = document.getElementById('hidden_seg_canvas');
+  let ctx = $('#hidden_seg_canvas').get(0).getContext('2d');
+  ctx.imageSmoothingEnabled = false;
+
+  ctx.drawImage(preCompRaw, 0, 0, rawWidth, rawHeight);
 
   // add labels on top
   ctx.save();

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1174,7 +1174,8 @@ function handle_mousedown(evt) {
         if (!brush.show) {
           brush.threshX = imgX;
           brush.threshY = imgY;
-        } else {
+        } else if (mode.kind !== Modes.prompt) {
+          // not if turning on conv brush
           mouse_trace.push([imgY, imgX]);
         }
       }
@@ -1184,8 +1185,10 @@ function handle_mousedown(evt) {
 
 function helper_brush_draw() {
   if (mousedown && !spacedown) {
-    // update mouse_trace
-    mouse_trace.push([imgY, imgX]);
+    // update mouse_trace, but not if turning on conv brush
+    if (mode.kind !== Modes.prompt) {
+      mouse_trace.push([imgY, imgX]);
+    }
   } else {
     brush.clearView();
   }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -708,6 +708,10 @@ let leftBorder = new Path2D();
 var rendering_raw = false;
 let display_invert = true;
 let display_labels;
+
+const MIN_CONTRAST = -100;
+const MAX_CONTRAST = 700;
+
 var current_contrast;
 let contrastMap = new Map();
 let brightness;
@@ -1155,9 +1159,9 @@ function handle_scroll(evt) {
     // don't use magnitude of scroll
     let mod_contrast = -Math.sign(evt.originalEvent.deltaY) * 4;
     // stop if fully desaturated
-    current_contrast = Math.max(current_contrast + mod_contrast, -100);
+    current_contrast = Math.max(current_contrast + mod_contrast, MIN_CONTRAST);
     // stop at 8x contrast
-    current_contrast = Math.min(current_contrast + mod_contrast, 700);
+    current_contrast = Math.min(current_contrast + mod_contrast, MAX_CONTRAST);
     prepareRaw();
   } else if ((rendering_raw || edit_mode || (rgb && !display_labels))
     && evt.originalEvent.shiftKey) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1156,8 +1156,8 @@ function handle_scroll(evt) {
     let mod_contrast = -Math.sign(evt.originalEvent.deltaY) * 4;
     // stop if fully desaturated
     current_contrast = Math.max(current_contrast + mod_contrast, -100);
-    // stop at 5x contrast
-    current_contrast = Math.min(current_contrast + mod_contrast, 400);
+    // stop at 8x contrast
+    current_contrast = Math.min(current_contrast + mod_contrast, 700);
     prepareRaw();
   } else if ((rendering_raw || edit_mode || (rgb && !display_labels))
     && evt.originalEvent.shiftKey) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1032,9 +1032,14 @@ function load_file(file) {
       // (each is a key in that dict), cast to numbers, then get the maximum
       // value from each array and store it in a map
       for (let i = 0; i < Object.keys(tracks).length; i++){
-        let key = Object.keys(tracks)[i]; //the keys are strings
-        //use i as key in this map because it is an int, mode.feature is also int
-        maxLabelsMap.set(i, Math.max(... Object.keys(tracks[key]).map(Number)));
+        let key = Object.keys(tracks)[i]; // the keys are strings
+        if (Object.keys(tracks[key]).length > 0) {
+          // use i as key in this map because it is an int, mode.feature is also int
+          maxLabelsMap.set(i, Math.max(... Object.keys(tracks[key]).map(Number)));
+        } else {
+          // if no labels in feature, explicitly set max label to 0
+          maxLabelsMap.set(i, 0);
+        }
       }
 
       for (let i = 0; i < channel_max; i++) {
@@ -1317,7 +1322,13 @@ function action(action, info, frame = current_frame) {
         // update maxLabelsMap when we get new track info
         for (let i = 0; i < Object.keys(tracks).length; i++){
           let key = Object.keys(tracks)[i]; // the keys are strings
-          maxLabelsMap.set(i, Math.max(...Object.keys(tracks[key]).map(Number)));
+          if (Object.keys(tracks[key]).length > 0) {
+            // use i as key in this map because it is an int, mode.feature is also int
+            maxLabelsMap.set(i, Math.max(... Object.keys(tracks[key]).map(Number)));
+          } else {
+            // if no labels in feature, explicitly set max label to 0
+            maxLabelsMap.set(i, 0);
+          }
         }
       }
       if (payload.tracks || payload.imgs) {


### PR DESCRIPTION
Adds option, in non-rgb pixel-only mode, to hide labels with "L" key, as users can't leave pixel-editing mode to view the raw-only image. Doesn't change existing rgb "L" functionality. Adds intermediate step to image processing cascade so that the adjusted, un-composited raw image can be easily displayed when "L" is toggled. Closes #173

Also addresses small bugs encountered while making instructions for HeLa movies:
- thresholding failed if no labels existed, due to edge case behavior when determining the maximum label value. Didn't seem to affect anything other than thresholding. Fixed by specifically accounting for that edge case
- setting the conversion brush with clicking would register the click locations as part of the `mouse_trace` and send those click coordinates next time the conversion brush was used. Fixed by not pushing coordinates to `mouse_trace` if in `prompt` mode (as opposed to `drawing` mode).