### PR TITLE
Update Pillow>=7.1.0 to resolve several moderate CVEs

### DIFF
--- a/browser/requirements.txt
+++ b/browser/requirements.txt
@@ -7,5 +7,5 @@ numpy>=1.16.4
 boto3==1.9.182
 scikit-image>=0.15.0,<0.17.0
 python-decouple==3.1
-pillow==6.2.2
+pillow>=7.1.0
 flask-compress==1.5.0


### PR DESCRIPTION
Several CVEs were found for Pillow < 7.1.0:

- CVE-2020-11538
- CVE-2020-10379
- CVE-2020-10994
- CVE-2020-10177