### PR TITLE
Browser/bugfix/update trk js

### DIFF
--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -211,7 +211,9 @@ class BaseReview(object):  # pylint: disable=useless-object-inheritance
             x_loc = loc[1]
             y_loc = loc[0]
 
-            brush_area = circle(y_loc, x_loc, brush_size, (self.height, self.width))
+            brush_area = circle(y_loc, x_loc,
+                                brush_size // self.scale_factor,
+                                (self.height, self.width))
 
             # do not overwrite or erase labels other than the one you're editing
             if not erase:

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -640,7 +640,7 @@ function render_edit_image(ctx) {
   ctx.restore();
 
   ctx.save();
-  let region = new Path2D();
+  const region = new Path2D();
   region.rect(padding, padding, dimensions[0], dimensions[1]);
   ctx.clip(region);
   ctx.imageSmoothingEnabled = true;

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -639,8 +639,15 @@ function render_edit_image(ctx) {
   ctx.drawImage(seg_image, padding, padding, dimensions[0], dimensions[1]);
   ctx.restore();
 
+  ctx.save();
+  let region = new Path2D();
+  region.rect(padding, padding, dimensions[0], dimensions[1]);
+  ctx.clip(region);
+  ctx.imageSmoothingEnabled = true;
+
   // draw brushview on top of cells/annotations
-  brush.draw(ctx);
+  brush.draw(ctx, 0, 0, dimensions[0], dimensions[1], 1);
+  ctx.restore();
 }
 
 function render_raw_image(ctx) {

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -291,10 +291,11 @@ class Mode {
 
   handle_draw() {
     action("handle_draw", {
-      "trace": JSON.stringify(mouse_trace),
-      "edit_value": brush.value,
-      "brush_size": brush.size,
-      "erase": brush.erase,
+      "trace": JSON.stringify(mouse_trace), // stringify array so it doesn't get messed up
+      "target_value": brush.target, // value that we're overwriting
+      "brush_value": brush.value, // we don't update caliban with edit_value, etc each time they change
+      "brush_size": brush.size, // so we need to pass them in as args
+      "erase": (brush.erase && !brush.conv),
       "frame": current_frame
     });
     mouse_trace = [];


### PR DESCRIPTION
Fixes trk javascript functionality (brush displays and draws correctly now). Doesn't update trk js to use the modules that the zstack js uses, just patches things for now.