### PR TITLE
Cursor, viewing window js classes

### DIFF
--- a/browser/.eslintrc
+++ b/browser/.eslintrc
@@ -1,0 +1,22 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": [
+    "standard"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "semi": "off",
+    "js-doc": "off",
+    "space-before-function-paren": "off"
+  }
+}

--- a/browser/.gitignore
+++ b/browser/.gitignore
@@ -1,4 +1,3 @@
-
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
@@ -6,3 +5,6 @@
 
 # python-decouple
 .env
+
+# JavaScript Dependencies
+node_modules/

--- a/browser/package.json
+++ b/browser/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-html": "^6.0.2",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1"
+  }
+}

--- a/browser/static/js/adjust.js
+++ b/browser/static/js/adjust.js
@@ -63,21 +63,6 @@ class ImageAdjuster {
     // composite image + outlines, transparent highlight
     this.postCompImg = new Image();
 
-    // TODO: these still rely on main js global variables, revisit in future
-    if (rgb) {
-      this.rawImage.onload = () => this.contrastRaw();
-      this.contrastedRaw.onload = () => this.rawAdjust(seg_array, current_highlight, edit_mode, brush, mode);
-      this.segImage.onload = () => this.preCompAdjust(seg_array, current_highlight, edit_mode, brush, mode);
-      this.preCompSeg.onload = () => this.segAdjust(seg_array, current_highlight, edit_mode, brush, mode);
-    } else {
-      this.rawImage.onload = () => this.contrastRaw();
-      this.contrastedRaw.onload = () => this.preCompRawAdjust();
-      this.preCompRaw.onload = () => this.rawAdjust(seg_array, current_highlight, edit_mode, brush, mode);
-      this.segImage.onload = () => this.preCompAdjust(seg_array, current_highlight, edit_mode, brush, mode);
-      this.preCompSeg.onload = () => this.segAdjust(seg_array, current_highlight, edit_mode, brush, mode);
-      this.compositedImg.onload = () => this.postCompAdjust(seg_array, edit_mode, brush);
-    }
-
     this.rawLoaded = false;
     this.segLoaded = false;
   }

--- a/browser/static/js/brush.js
+++ b/browser/static/js/brush.js
@@ -1,5 +1,5 @@
 class Brush {
-  constructor(scale, height, width, pad) {
+  constructor(height, width, pad) {
     // center of brush (scaled)
     this.x = 0;
     this.y = 0;
@@ -38,8 +38,6 @@ class Brush {
     this._height = height;
     this._width = width;
     this._padding = pad;
-
-    this.scale = scale;
 
     // create hidden canvas to store brush preview
     this.canvas = document.createElement('canvas');

--- a/browser/static/js/brush.js
+++ b/browser/static/js/brush.js
@@ -39,6 +39,8 @@ class Brush {
     this._width = width;
     this._padding = pad;
 
+    this.scale = scale;
+
     // create hidden canvas to store brush preview
     this.canvas = document.createElement('canvas');
     this.canvas.id = 'brushCanvas';

--- a/browser/static/js/brush.js
+++ b/browser/static/js/brush.js
@@ -226,7 +226,14 @@ class Brush {
   }
 
   // draw brush preview onto destination ctx
-  draw(ctxDst, sx, sy, swidth, sheight, mag) {
+  draw(ctxDst, viewer) {
+    // get attributes from viewer object
+    const sx = viewer.sx;
+    const sy = viewer.sy;
+    const swidth = viewer.sWidth;
+    const sheight = viewer.sHeight;
+    const mag = viewer.scale * viewer.zoom / 100;
+
     // draw translucent brush trace
     ctxDst.save();
     ctxDst.globalAlpha = this._opacity;

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -11,6 +11,9 @@ class CalibanCursor {
     // mouse position on canvas, no adjustment for padding
     this.rawX = 0;
     this.rawY = 0;
+    // adjusted for padding
+    this.canvasPosX = -5;
+    this.canvasPosY = -5;
   }
 
   // check if the mouse position in canvas matches to a displayed part of image

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -6,6 +6,11 @@ class CalibanCursor {
     this.scale = scale;
     this.pressed = false;
     this.trace = [];
+
+    // mouse coords
+    // mouse position on canvas, no adjustment for padding
+    this.rawX = 0;
+    this.rawY = 0;
   }
 
   // check if the mouse position in canvas matches to a displayed part of image

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -7,6 +7,17 @@ class CalibanCursor {
     this.pressed = false;
     this.trace = [];
   }
+
+  // check if the mouse position in canvas matches to a displayed part of image
+  inRange(x, y) {
+    if (x >= 0 && x < this.width * this.scale &&
+        y >= 0 && y < this.height * this.scale) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
 }
 
 // handle updating zooming and panning attributes

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -1,3 +1,7 @@
+// NOTE: cursor and viewer are more abstract than the brush,
+// how they should relate to each other is an open question.
+// eg, should scale/dimensions be attributes only of viewer? etc
+
 // cursor to handle mouse movement and attributes
 class CalibanCursor {
   constructor(width, height, scale) {

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -2,6 +2,7 @@
 class CalibanCursor {
   constructor() {
     this.pressed = false;
+    this.trace = [];
   }
 }
 

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -35,7 +35,84 @@ class CanvasView {
 
     this.scale = 1;
 
+    this.topBorder = new Path2D();
+    this.bottomBorder = new Path2D();
+    this.rightBorder = new Path2D();
+    this.leftBorder = new Path2D();
+
   }
+
+  setBorders(padding) {
+    const scaledWidth = this.scale * this.width;
+    const scaledHeight = this.scale * this.height;
+
+    // create paths for recoloring borders
+    this.topBorder = new Path2D();
+    this.topBorder.moveTo(0, 0);
+    this.topBorder.lineTo(padding, padding);
+    this.topBorder.lineTo(scaledWidth + padding, padding);
+    this.topBorder.lineTo(scaledWidth + 2 * padding, 0);
+    this.topBorder.closePath();
+
+    this.bottomBorder = new Path2D();
+    this.bottomBorder.moveTo(0, scaledHeight + 2 * padding);
+    this.bottomBorder.lineTo(padding, scaledHeight + padding);
+    this.bottomBorder.lineTo(scaledWidth + padding, scaledHeight + padding);
+    this.bottomBorder.lineTo(scaledWidth + 2 * padding, scaledHeight + 2 * padding);
+    this.bottomBorder.closePath();
+
+    this.leftBorder = new Path2D();
+    this.leftBorder.moveTo(0, 0);
+    this.leftBorder.lineTo(0, scaledHeight + 2 * padding);
+    this.leftBorder.lineTo(padding, scaledHeight + padding);
+    this.leftBorder.lineTo(padding, padding);
+    this.leftBorder.closePath();
+
+    this.rightBorder = new Path2D();
+    this.rightBorder.moveTo(scaledWidth + 2 * padding, 0);
+    this.rightBorder.lineTo(scaledWidth + padding, padding);
+    this.rightBorder.lineTo(scaledWidth + padding, scaledHeight + padding);
+    this.rightBorder.lineTo(scaledWidth + 2 * padding, scaledHeight + 2 * padding);
+    this.rightBorder.closePath();
+  }
+
+  drawBorders(ctx) {
+    ctx.save();
+    // left border
+    if (Math.floor(this.sx) === 0) {
+      ctx.fillStyle = 'white';
+    } else {
+      ctx.fillStyle = 'black';
+    }
+    ctx.fill(this.leftBorder);
+
+    // right border
+    if (Math.ceil(this.sx + this.sWidth) === this.width) {
+      ctx.fillStyle = 'white';
+    } else {
+      ctx.fillStyle = 'black';
+    }
+    ctx.fill(this.rightBorder);
+
+    // top border
+    if (Math.floor(this.sy) === 0) {
+      ctx.fillStyle = 'white';
+    } else {
+      ctx.fillStyle = 'black';
+    }
+    ctx.fill(this.topBorder);
+
+    // bottom border
+    if (Math.ceil(this.sy + this.sHeight) === this.height) {
+      ctx.fillStyle = 'white';
+    } else {
+      ctx.fillStyle = 'black';
+    }
+    ctx.fill(this.bottomBorder);
+
+    ctx.restore();
+  }
+
 
   pan(dx, dy) {
     let tempPanX = this.sx - dx;

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -1,0 +1,45 @@
+// cursor to handle mouse movement and attributes
+class CalibanCursor {
+  constructor() {
+    this.pressed = false;
+  }
+}
+
+// handle updating zooming and panning attributes
+class CanvasView {
+  constructor(width, height) {
+
+    this.width = width;
+    this.height = height;
+    this.sx = 0;
+    this.sy = 0;
+    this.sWidth = 0;
+    this.sHeight = 0;
+    this.zoom = 100;
+    this.zoomLimit = 100;
+
+  }
+
+  pan(dx, dy) {
+    let tempPanX = this.sx - dx;
+    let tempPanY = this.sy - dy;
+
+    // stop panning if at the edge of image (x)
+    if (tempPanX >= 0 && tempPanX + this.sWidth < this.width) {
+      this.sx = tempPanX;
+    } else {
+      tempPanX = Math.max(0, tempPanX);
+      this.sx = Math.min(this.width - this.sWidth, tempPanX);
+    }
+
+    // stop panning if at the edge of image (y)
+    if (tempPanY >= 0 && tempPanY + this.sHeight < this.height) {
+      this.sy = tempPanY;
+    } else {
+      tempPanY = Math.max(0, tempPanY);
+      this.sy = Math.min(this.height - this.sHeight, tempPanY);
+    }
+  }
+
+
+}

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -17,9 +17,9 @@ class CalibanCursor {
   }
 
   // check if the mouse position in canvas matches to a displayed part of image
-  inRange(x, y) {
-    if (x >= 0 && x < this.width * this.scale &&
-        y >= 0 && y < this.height * this.scale) {
+  inRange() {
+    if (this.canvasPosX >= 0 && this.canvasPosX < this.width * this.scale &&
+        this.canvasPosY >= 0 && this.canvasPosY < this.height * this.scale) {
       return true;
     } else {
       return false;

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -25,8 +25,23 @@ class CalibanCursor {
     this.storedClickX;
     this.storedClickY;
 
+    this.label = 0;
     // store as part of object to be able to get current label
-    this.segArray;
+    this._segArray;
+  }
+
+  get segArray() {
+    return this._segArray;
+  }
+
+  set segArray(newSegArray) {
+    this._segArray = newSegArray;
+    if (this.inRange()) {
+      this.label = Math.abs(this.segArray[this.imgY][this.imgX]);
+    } else {
+      this.label = 0;
+    }
+
   }
 
   // check if the mouse position in canvas matches to a displayed part of image
@@ -52,17 +67,10 @@ class CalibanCursor {
     if (this.inRange()) {
       this.imgX = Math.floor((this.canvasPosX * 100 / (viewer.scale * viewer.zoom) + viewer.sx));
       this.imgY = Math.floor((this.canvasPosY * 100 / (viewer.scale * viewer.zoom) + viewer.sy));
-    }
-  }
-
-  getCurrentLabel() {
-    let label;
-    if (this.inRange()) {
-      label = Math.abs(this.segArray[this.imgY][this.imgX]);
+      this.label = Math.abs(this.segArray[this.imgY][this.imgX]);
     } else {
-      label = 0;
+      this.label = 0;
     }
-    return label;
   }
 
 }

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -17,6 +17,9 @@ class CalibanCursor {
     // coordinates in original image (used for actions, labels, etc)
     this.imgX;
     this.imgY;
+    // what imgX and imgY were upon most recent click
+    this.storedClickX;
+    this.storedClickY;
   }
 
   // check if the mouse position in canvas matches to a displayed part of image

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -45,6 +45,16 @@ class CalibanCursor {
     }
   }
 
+  getCurrentLabel(segArray) {
+    let label;
+    if (this.inRange()) {
+      label = Math.abs(segArray[this.imgY][this.imgX]);
+    } else {
+      label = 0;
+    }
+    return label;
+  }
+
 }
 
 // handle updating zooming and panning attributes

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -33,6 +33,8 @@ class CanvasView {
     this.zoom = 100;
     this.zoomLimit = 100;
 
+    this.scale = 1;
+
   }
 
   pan(dx, dy) {

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -13,8 +13,8 @@ class CanvasView {
     this.height = height;
     this.sx = 0;
     this.sy = 0;
-    this.sWidth = 0;
-    this.sHeight = 0;
+    this.sWidth = width;
+    this.sHeight = height;
     this.zoom = 100;
     this.zoomLimit = 100;
 

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -135,5 +135,31 @@ class CanvasView {
     }
   }
 
+  changeZoom(dZoom, canvasPosX, canvasPosY) {
+    const newZoom = this.zoom - 10*dZoom;
+    const oldZoom = this.zoom;
+    const newHeight = this.height * 100 / newZoom;
+    const newWidth = this.width * 100 / newZoom;
+
+    // store sWidth and sHeight to compare against for panning
+    const oldHeight = this.sHeight;
+    const oldWidth = this.sWidth;
+
+    if (newZoom >= this.zoomLimit) {
+      this.zoom = newZoom;
+      this.sHeight = newHeight;
+      this.sWidth = newWidth;
+    }
+    if (oldZoom !== newZoom) {
+      const scaledWidth = this.scale * this.width;
+      const scaledHeight = this.scale * this.height;
+      const propX = canvasPosX / scaledWidth;
+      const propY = canvasPosY / scaledHeight;
+      const dx = propX * (newWidth - oldWidth);
+      const dy = propY * (newHeight - oldHeight);
+      this.pan(dx, dy);
+    }
+  }
+
 
 }

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -24,6 +24,9 @@ class CalibanCursor {
     // what imgX and imgY were upon most recent click
     this.storedClickX;
     this.storedClickY;
+
+    // store as part of object to be able to get current label
+    this.segArray;
   }
 
   // check if the mouse position in canvas matches to a displayed part of image
@@ -52,10 +55,10 @@ class CalibanCursor {
     }
   }
 
-  getCurrentLabel(segArray) {
+  getCurrentLabel() {
     let label;
     if (this.inRange()) {
-      label = Math.abs(segArray[this.imgY][this.imgX]);
+      label = Math.abs(this.segArray[this.imgY][this.imgX]);
     } else {
       label = 0;
     }

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -1,6 +1,9 @@
 // cursor to handle mouse movement and attributes
 class CalibanCursor {
-  constructor() {
+  constructor(width, height, scale) {
+    this.width = width
+    this.height = height
+    this.scale = scale;
     this.pressed = false;
     this.trace = [];
   }

--- a/browser/static/js/cursor.js
+++ b/browser/static/js/cursor.js
@@ -14,6 +14,9 @@ class CalibanCursor {
     // adjusted for padding
     this.canvasPosX = -5;
     this.canvasPosY = -5;
+    // coordinates in original image (used for actions, labels, etc)
+    this.imgX;
+    this.imgY;
   }
 
   // check if the mouse position in canvas matches to a displayed part of image
@@ -23,6 +26,22 @@ class CalibanCursor {
       return true;
     } else {
       return false;
+    }
+  }
+
+  updatePos(x, y, padding, viewer) {
+    // store raw mouse position, in case of pan without mouse movement
+    this.rawX = x;
+    this.rawY = y;
+
+    // convert to viewing pane position, to check whether to access label underneath
+    this.canvasPosX = x - padding;
+    this.canvasPosY = y - padding;
+
+    // convert to image indices, to use for actions and getting label
+    if (this.inRange()) {
+      this.imgX = Math.floor((this.canvasPosX * 100 / (viewer.scale * viewer.zoom) + viewer.sx));
+      this.imgY = Math.floor((this.canvasPosY * 100 / (viewer.scale * viewer.zoom) + viewer.sy));
     }
   }
 

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -863,18 +863,18 @@ function action(action, info, frame = current_frame) {
   });
 }
 
-function start_caliban(filename) {
+function startCaliban(filename, settings) {
   // disable scrolling from scrolling around on page (it should just control brightness)
   document.addEventListener('wheel', function(event) {
     event.preventDefault();
-  }, {passive: false});
+  }, { passive: false });
   // disable space and up/down keys from moving around on page
-  $(document).on('keydown', function(event) {
-    if (event.key === " ") {
+  document.addEventListener('keydown', function(event) {
+    if (event.key === ' ') {
       event.preventDefault();
-    } else if (event.key === "ArrowUp") {
+    } else if (event.key === 'ArrowUp') {
       event.preventDefault();
-    } else if (event.key === "ArrowDown") {
+    } else if (event.key === 'ArrowDown') {
       event.preventDefault();
     }
   });

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -697,6 +697,7 @@ let mouse_trace = [];
 var brush;
 var adjust;
 let cursor;
+let viewer;
 
 var waitForFinalEvent = (function () {
   var timers = {};
@@ -1339,6 +1340,7 @@ function start_caliban(filename) {
   load_file(filename);
 
   cursor = new CalibanCursor();
+  viewer = new CanvasView(width=rawWidth, height=rawHeight);
 
   // define image onload cascade behavior, need rawHeight and rawWidth first
   adjuster = new ImageAdjuster(width=rawWidth, height=rawHeight,

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -651,6 +651,8 @@ var dimensions;
 
 const padding = 5;
 
+// TODO: this could go into adjuster and cursor classes
+// upon update, not needed by any other objects
 var seg_array; // declare here so it is global var
 
 var rendering_raw = false;
@@ -772,7 +774,7 @@ function render_cell_info() {
   // TODO: could also change to add seg_array as attribute of cursor object
   // so that current_label becomes cursor.label and is updated on mouse movement,
   // cursor.seg_array updated on new seg_array being loaded
-  current_label = cursor.getCurrentLabel(seg_array);
+  current_label = cursor.getCurrentLabel();
   if (current_label !== 0) {
     $('#label').html(current_label);
     let track = tracks[mode.feature][current_label.toString()];
@@ -890,6 +892,7 @@ function fetch_and_render_frame() {
       // load new value of seg_array
       // array of arrays, contains annotation data for frame
       seg_array = payload.seg_arr;
+      cursor.segArray = seg_array;
       adjuster.segImage.src = payload.segmented;
       adjuster.rawImage.src = payload.raw;
     },
@@ -1143,6 +1146,7 @@ function action(action, info, frame = current_frame) {
         // array of arrays, contains annotation data for frame
         if (payload.imgs.hasOwnProperty('seg_arr')) {
           seg_array = payload.imgs.seg_arr;
+          cursor.segArray = seg_array;
         }
 
         if (payload.imgs.hasOwnProperty('segmented')) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -6,9 +6,8 @@ class Mode {
     this.highlighted_cell_two = -1;
     this.feature = 0;
     this._channel = 0;
-    this.action = "";
-    this.prompt = "";
-
+    this.action = '';
+    this.prompt = '';
   }
 
   get channel() {
@@ -31,8 +30,8 @@ class Mode {
         this._channel = num;
       }
       // get new channel image from server
-      this.info = {"channel": this._channel};
-      action("change_channel", this.info);
+      this.info = { channel: this._channel };
+      action('change_channel', this.info);
       this.clear();
       // get brightness/contrast vals for new channel
       adjuster.brightness = adjuster.brightnessMap.get(this._channel);
@@ -50,9 +49,9 @@ class Mode {
     brush.conv = false;
     brush.clearThresh();
 
-    this.action = "";
-    this.prompt = "";
-    adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+    this.action = '';
+    this.prompt = '';
+    adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
   }
 
   // these keybinds apply regardless of
@@ -72,14 +71,14 @@ class Mode {
         current_frame = 0;
       }
       fetch_and_render_frame();
-    } else if (key === "Escape") {
+    } else if (key === 'Escape') {
       // deselect/cancel action/reset highlight
       mode.clear();
       // may want some things here that trigger on ESC but not clear()
     } else if (!rgb && key === 'h') {
       // toggle highlight
       current_highlight = !current_highlight;
-      adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+      adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
     } else if (key === 'z') {
       // toggle rendering_raw
       rendering_raw = !rendering_raw;
@@ -100,12 +99,12 @@ class Mode {
   // keybinds that always apply in edit mode
   // (invert, change brush size)
   handle_universal_edit_keybind(key) {
-    if (key === "ArrowDown") {
+    if (key === 'ArrowDown') {
       // decrease brush size, minimum size 1
       brush.size -= 1;
       // redraw the frame with the updated brush preview
       render_image_display();
-    } else if (key === "ArrowUp") {
+    } else if (key === 'ArrowUp') {
       // increase brush size, diameter shouldn't be larger than the image
       brush.size += 1;
       // redraw the frame with the updated brush preview
@@ -120,79 +119,80 @@ class Mode {
       // set edit value to something unused
       brush.value = maxLabelsMap.get(this.feature) + 1;
       if (this.kind === Modes.prompt && brush.conv) {
-        this.prompt = "Now drawing over label " + brush.target + " with label " + brush.value
-            + ". Use ESC to leave this mode.";
+        this.prompt = `Now drawing over label ${brush.target} with label ${brush.value}. Use ESC to leave this mode.`;
         this.kind = Modes.drawing;
       }
-      adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+      adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
     }
   }
 
   // keybinds that apply when in edit mode
   handle_edit_keybind(key) {
-    if (key === "e" && !settings.pixel_only) {
+    if (key === 'e' && !settings.pixel_only) {
       // toggle edit mode
       edit_mode = !edit_mode;
-      adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
-    } else if (key === "c") {
+      adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
+    } else if (key === 'c') {
       // cycle forward one channel, if applicable
       this.channel += 1;
-    } else if (key === "C") {
+    } else if (key === 'C') {
       // cycle backward one channel, if applicable
       this.channel -= 1;
-    } else if (key === "f") {
+    } else if (key === 'f') {
       // cycle forward one feature, if applicable
       if (feature_max > 1) {
-        this.feature = this.increment_value(this.feature, 0, feature_max -1);
-        this.info = {"feature": this.feature};
-        action("change_feature", this.info);
+        this.feature = this.increment_value(this.feature, 0, feature_max - 1);
+        this.info = { feature: this.feature };
+        action('change_feature', this.info);
         this.clear();
       }
-    } else if (key === "F") {
+    } else if (key === 'F') {
       // cycle backward one feature, if applicable
       if (feature_max > 1) {
-        this.feature = this.decrement_value(this.feature, 0, feature_max -1);
-        this.info = {"feature": this.feature};
-        action("change_feature", this.info);
+        this.feature = this.decrement_value(this.feature, 0, feature_max - 1);
+        this.info = { feature: this.feature };
+        action('change_feature', this.info);
         this.clear();
       }
-    } else if (key === "]") {
+    } else if (key === ']') {
       // increase edit_value up to max label + 1 (guaranteed unused)
-      brush.value = Math.min(brush.value + 1,
-                             maxLabelsMap.get(this.feature) + 1);
+      brush.value = Math.min(
+        brush.value + 1,
+        maxLabelsMap.get(this.feature) + 1
+      );
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       }
       render_info_display();
-    } else if (key === "[") {
+    } else if (key === '[') {
       // decrease edit_value, minimum 1
       brush.value -= 1;
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       }
       render_info_display();
-    } else if (key === "x") {
+    } else if (key === 'x') {
       // turn eraser on and off
       brush.erase = !brush.erase;
       render_image_display();
     } else if (key === 'p') {
       // color picker
       this.kind = Modes.prompt;
-      this.action = "pick_color";
-      this.prompt = "Click on a label to change the brush value to that value.";
+      this.action = 'pick_color';
+      this.prompt = 'Click on a label to change the brush value to that value.';
       render_info_display();
     } else if (key === 'r') {
       // conversion brush
       this.kind = Modes.prompt;
-      this.action = "pick_target";
-      this.prompt = "First, click on the label you want to overwrite.";
+      this.action = 'pick_target';
+      this.prompt = 'First, click on the label you want to overwrite.';
       brush.conv = true;
       render_image_display();
     } else if (key === 't' && !rgb) {
       // prompt thresholding with bounding box
       this.kind = Modes.question;
-      this.action = "start_threshold";
-      this.prompt = "Click and drag to create a bounding box around the area you want to threshold";
+      this.action = 'start_threshold';
+      this.prompt = 'Click and drag to create a bounding box around the area you want to threshold.';
       brush.show = false;
       brush.clearView();
       render_image_display();
@@ -201,155 +201,169 @@ class Mode {
 
   // keybinds that apply in bulk mode, nothing selected
   handle_mode_none_keybind(key) {
-    if (key === "e" && !settings.label_only) {
+    if (key === 'e' && !settings.label_only) {
       // toggle edit mode
       edit_mode = !edit_mode;
       helper_brush_draw();
-      adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
-    } else if (key === "c") {
+      adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
+    } else if (key === 'c') {
       // cycle forward one channel, if applicable
       this.channel += 1;
-    } else if (key === "C") {
+    } else if (key === 'C') {
       // cycle backward one channel, if applicable
       this.channel -= 1;
-    } else if (key === "f") {
+    } else if (key === 'f') {
       // cycle forward one feature, if applicable
       if (feature_max > 1) {
-        this.feature = this.increment_value(this.feature, 0, feature_max -1);
-        this.info = {"feature": this.feature};
-        action("change_feature", this.info);
+        this.feature = this.increment_value(this.feature, 0, feature_max - 1);
+        this.info = { feature: this.feature };
+        action('change_feature', this.info);
         this.clear();
       }
-    } else if (key === "F") {
+    } else if (key === 'F') {
       // cycle backward one feature, if applicable
       if (feature_max > 1) {
-        this.feature = this.decrement_value(this.feature, 0, feature_max -1);
-        this.info = {"feature": this.feature};
-        action("change_feature", this.info);
+        this.feature = this.decrement_value(this.feature, 0, feature_max - 1);
+        this.info = { feature: this.feature };
+        action('change_feature', this.info);
         this.clear();
       }
-    } else if (key === "p" && !rgb) {
-      //iou cell identity prediction
+    } else if (key === 'p' && !rgb) {
+      // iou cell identity prediction
       this.kind = Modes.question;
-      this.action = "predict";
-      this.prompt = "Predict cell ids for zstack? / S=PREDICT THIS FRAME / SPACE=PREDICT ALL FRAMES / ESC=CANCEL PREDICTION";
+      this.action = 'predict';
+      this.prompt = 'Predict cell ids for zstack? / S=PREDICT THIS FRAME / SPACE=PREDICT ALL FRAMES / ESC=CANCEL PREDICTION';
       render_info_display();
-    } else if (key === "[" && this.highlighted_cell_one !== -1) {
+    } else if (key === '[' && this.highlighted_cell_one !== -1) {
       // cycle highlight to prev label
-      this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
-          1, maxLabelsMap.get(this.feature));
+      this.highlighted_cell_one = this.decrement_value(
+        this.highlighted_cell_one,
+        1,
+        maxLabelsMap.get(this.feature)
+      );
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       }
-    } else if (key === "]" && this.highlighted_cell_one !== -1) {
+    } else if (key === ']' && this.highlighted_cell_one !== -1) {
       // cycle highlight to next label
-      this.highlighted_cell_one = this.increment_value(this.highlighted_cell_one,
-          1, maxLabelsMap.get(this.feature));
+      this.highlighted_cell_one = this.increment_value(
+        this.highlighted_cell_one,
+        1,
+        maxLabelsMap.get(this.feature)
+      );
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       }
     }
   }
 
   // keybinds that apply in bulk mode, one selected
   handle_mode_single_keybind(key) {
-    if (key === "f" && !rgb) {
-      //hole fill
+    if (key === 'f' && !rgb) {
+      // hole fill
       this.info = {
-        "label": this.info.label,
-        "frame": current_frame
+        label: this.info.label,
+        frame: current_frame
       };
       this.kind = Modes.prompt;
-      this.action = "fill_hole";
-      this.prompt = "Select hole to fill in cell " + this.info.label;
+      this.action = 'fill_hole';
+      this.prompt = `Select hole to fill in cell ${this.info.label}`;
       render_info_display();
-    } else if (!rgb && key === "c") {
+    } else if (!rgb && key === 'c') {
       // create new
       this.kind = Modes.question;
-      this.action = "create_new";
-      this.prompt = "CREATE NEW(S=SINGLE FRAME / SPACE=ALL SUBSEQUENT FRAMES / ESC=NO)";
+      this.action = 'create_new';
+      this.prompt = 'CREATE NEW(S=SINGLE FRAME / SPACE=ALL SUBSEQUENT FRAMES / ESC=NO)';
       render_info_display();
-    } else if (key === "x") {
+    } else if (key === 'x') {
       // delete label from frame
       this.kind = Modes.question;
-      this.action = "delete_mask";
-      this.prompt = "delete label " + this.info.label + " in frame " + this.info.frame + "? " + answer;
+      this.action = 'delete_mask';
+      this.prompt = `delete label ${this.info.label} in frame ${this.info.frame}? ${answer}`;
       render_info_display();
-    } else if (key === "[") {
+    } else if (key === '[') {
       // cycle highlight to prev label
-      this.highlighted_cell_one = this.decrement_value(this.highlighted_cell_one,
-          1, maxLabelsMap.get(this.feature));
+      this.highlighted_cell_one = this.decrement_value(
+        this.highlighted_cell_one,
+        1,
+        maxLabelsMap.get(this.feature)
+      );
       // clear info but show new highlighted cell
-      let temp_highlight = this.highlighted_cell_one;
+      const tempHighlight = this.highlighted_cell_one;
       this.clear();
-      this.highlighted_cell_one = temp_highlight;
+      this.highlighted_cell_one = tempHighlight;
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       }
-    } else if (key === "]") {
+    } else if (key === ']') {
       // cycle highlight to next label
-      this.highlighted_cell_one = this.increment_value(this.highlighted_cell_one,
-          1, maxLabelsMap.get(this.feature));
+      this.highlighted_cell_one = this.increment_value(
+        this.highlighted_cell_one,
+        1,
+        maxLabelsMap.get(this.feature)
+      );
       // clear info but show new highlighted cell
-      let temp_highlight = this.highlighted_cell_one;
+      const tempHighlight = this.highlighted_cell_one;
       this.clear();
-      this.highlighted_cell_one = temp_highlight;
+      this.highlighted_cell_one = tempHighlight;
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       }
     }
   }
 
   // keybinds that apply in bulk mode, two selected
   handle_mode_multiple_keybind(key) {
-    if (key === "r") {
+    if (key === 'r') {
       // replace
       this.kind = Modes.question;
-      this.action = "replace";
-      this.prompt = ("Replace " + this.info.label_2 + " with " + this.info.label_1 +
-        "? // SPACE = Replace in all frames / S = Replace in this frame only / ESC = Cancel replace");
+      this.action = 'replace';
+      this.prompt = ('Replace ' + this.info.label_2 + ' with ' + this.info.label_1 +
+        '? // SPACE = Replace in all frames / S = Replace in this frame only / ESC = Cancel replace');
       render_info_display();
-    } else if (!rgb && key === "s") {
+    } else if (!rgb && key === 's') {
       // swap
       this.kind = Modes.question;
-      this.action = "swap_cells";
-      this.prompt = "SPACE = SWAP IN ALL FRAMES / S = SWAP IN THIS FRAME ONLY / ESC = CANCEL SWAP";
+      this.action = 'swap_cells';
+      this.prompt = 'SPACE = SWAP IN ALL FRAMES / S = SWAP IN THIS FRAME ONLY / ESC = CANCEL SWAP';
       render_info_display();
-    } else if (key === "w" && !rgb) {
+    } else if (key === 'w' && !rgb) {
       // watershed
       this.kind = Modes.question;
-      this.action = "watershed";
-      this.prompt = "Perform watershed to split " + this.info.label_1 + "? " + answer;
+      this.action = 'watershed';
+      this.prompt = `Perform watershed to split ${this.info.label_1}? ${answer}`;
       render_info_display();
     }
   }
 
   // keybinds that apply in bulk mode, answering question/prompt
   handle_mode_question_keybind(key) {
-    if (key === " ") {
-      if (this.action === "flood_contiguous") {
-        action("flood_contiguous", this.info);
-      } else if (this.action === "trim_pixels") {
-        action("trim_pixels", this.info);
-      } else if (this.action === "create_new") {
-        action("new_cell_stack", this.info);
-      } else if (this.action === "delete_mask") {
-        action("delete_mask", this.info);
-      } else if (this.action === "predict") {
-        action("predict_zstack", this.info);
-      } else if (this.action === "replace") {
+    if (key === ' ') {
+      if (this.action === 'flood_contiguous') {
+        action(this.action, this.info);
+      } else if (this.action === 'trim_pixels') {
+        action(this.action, this.info);
+      } else if (this.action === 'create_new') {
+        action('new_cell_stack', this.info);
+      } else if (this.action === 'delete_mask') {
+        action(this.action, this.info);
+      } else if (this.action === 'predict') {
+        action('predict_zstack', this.info);
+      } else if (this.action === 'replace') {
         if (this.info.label_1 !== this.info.label_2) {
-          let send_info = {"label_1": this.info.label_1,
-                          "label_2": this.info.label_2};
-          action("replace", send_info);
+          action(this.action, {
+            label_1: this.info.label_1,
+            label_2: this.info.label_2
+          });
         }
-      } else if (this.action === "swap_cells") {
+      } else if (this.action === 'swap_cells') {
         if (this.info.label_1 !== this.info.label_2) {
-          let send_info = {"label_1": this.info.label_1,
-                          "label_2": this.info.label_2};
-          action("swap_all_frame", send_info);
+          action('swap_all_frame', {
+            label_1: this.info.label_1,
+            label_2: this.info.label_2
+          });
         }
-      } else if (this.action === "watershed") {
+      } else if (this.action === 'watershed') {
         if (this.info.label_1 === this.info.label_2 &&
             this.info.frame_1 === this.info.frame_2) {
           this.info.frame = this.info.frame_1;
@@ -362,26 +376,28 @@ class Mode {
         }
       }
       this.clear();
-    } else if (key === "s") {
-      if(this.action === "create_new") {
-        action("new_single_cell", this.info);
-      } else if (this.action === "predict") {
-        action("predict_single", {"frame": current_frame});
-      } else if (this.action === "replace") {
+    } else if (key === 's') {
+      if (this.action === 'create_new') {
+        action('new_single_cell', this.info);
+      } else if (this.action === 'predict') {
+        action('predict_single', { frame: current_frame });
+      } else if (this.action === 'replace') {
         if (this.info.label_1 !== this.info.label_2 &&
             this.info.frame_1 === this.info.frame_2) {
-          let send_info = {"label_1": this.info.label_1,
-                            "label_2": this.info.label_2,
-                            "frame": this.info.frame_1};
-          action("replace_single", send_info);
+          action('replace_single', {
+            label_1: this.info.label_1,
+            label_2: this.info.label_2,
+            frame: this.info.frame_1
+          });
         }
-      } else if (this.action === "swap_cells") {
+      } else if (this.action === 'swap_cells') {
         if (this.info.label_1 !== this.info.label_2 &&
             this.info.frame_1 === this.info.frame_2) {
-          let send_info = {"label_1": this.info.label_1,
-                            "label_2": this.info.label_2,
-                            "frame": this.info.frame_1};
-          action("swap_single_frame", send_info);
+          action('swap_single_frame', {
+            label_1: this.info.label_1,
+            label_2: this.info.label_2,
+            frame: this.info.frame_1
+          });
         }
       }
       this.clear();
@@ -411,38 +427,35 @@ class Mode {
   }
 
   handle_draw() {
-    action("handle_draw", {
-      // TODO: getter for cursor.trace that stringifies it
-      "trace": JSON.stringify(cursor.trace), // stringify array so it doesn't get messed up
-      "target_value": brush.target, // value that we're overwriting
-      "brush_value": brush.value, // we don't update caliban with edit_value, etc each time they change
-      "brush_size": brush.size, // so we need to pass them in as args
-      "erase": (brush.erase && !brush.conv),
-      "frame": current_frame
+    action('handle_draw', {
+      trace: JSON.stringify(state.trace), // stringify array so it doesn't get messed up
+      target_value: brush.target, // value that we're overwriting
+      brush_value: brush.value, // we don't update caliban with edit_value, etc each time they change
+      brush_size: brush.size, // so we need to pass them in as args
+      erase: (brush.erase && !brush.conv),
+      frame: current_frame
     });
-    // TODO: cursor.clearTrace ?
-    cursor.trace = [];
+    state.clearTrace();
     if (this.kind !== Modes.drawing) {
       this.clear();
     }
   }
 
   handle_threshold() {
-    let threshold_start_y = brush.threshY;
-    let threshold_start_x = brush.threshX;
-    let threshold_end_x = cursor.imgX;
-    let threshold_end_y = cursor.imgY;
+    const thresholdStartY = brush.threshY;
+    const thresholdStartX = brush.threshX;
+    const thresholdEndX = state.imgX;
+    const thresholdEndY = state.imgY;
 
-    if (threshold_start_y !== threshold_end_y &&
-        threshold_start_x !== threshold_end_x) {
-
-      action("threshold", {
-        "y1": threshold_start_y,
-        "x1": threshold_start_x,
-        "y2": threshold_end_y,
-        "x2": threshold_end_x,
-        "frame": current_frame,
-        "label": maxLabelsMap.get(this.feature) + 1
+    if (thresholdStartY !== thresholdEndY &&
+        thresholdStartX !== thresholdEndX) {
+      action('threshold', {
+        y1: thresholdStartY,
+        x1: thresholdStartX,
+        y2: thresholdEndY,
+        x2: thresholdEndX,
+        frame: current_frame,
+        label: maxLabelsMap.get(this.feature) + 1
       });
     }
     this.clear();
@@ -469,72 +482,70 @@ class Mode {
     return currentValue;
   }
 
-  // TODO: cursor.click(evt, mode) ?
+  // TODO: state.click(evt, mode) ?
   handle_mode_none_click(evt) {
     if (evt.altKey) {
       // alt+click
       this.kind = Modes.question;
-      this.action = "flood_contiguous";
+      this.action = 'flood_contiguous';
       this.info = {
-        "label": cursor.label,
-        "frame": current_frame,
-        "x_location": cursor.imgX,
-        "y_location": cursor.imgY
+        label: state.label,
+        frame: current_frame,
+        x_location: state.imgX,
+        y_location: state.imgY
       };
-      this.prompt = "SPACE = FLOOD SELECTED CELL WITH NEW LABEL / ESC = CANCEL";
-      this.highlighted_cell_one = cursor.label;
+      this.prompt = 'SPACE = FLOOD SELECTED CELL WITH NEW LABEL / ESC = CANCEL';
+      this.highlighted_cell_one = state.label;
     } else if (evt.shiftKey) {
       // shift+click
       this.kind = Modes.question;
-      this.action = "trim_pixels";
+      this.action = 'trim_pixels';
       this.info = {
-        "label": cursor.label,
-        "frame": current_frame,
-        "x_location": cursor.imgX,
-        "y_location": cursor.imgY
+        label: state.label,
+        frame: current_frame,
+        x_location: state.imgX,
+        y_location: state.imgY
       };
-      this.prompt = "SPACE = TRIM DISCONTIGUOUS PIXELS FROM CELL / ESC = CANCEL";
-      this.highlighted_cell_one = cursor.label;
+      this.prompt = 'SPACE = TRIM DISCONTIGUOUS PIXELS FROM CELL / ESC = CANCEL';
+      this.highlighted_cell_one = state.label;
     } else {
       // normal click
       this.kind = Modes.single;
       this.info = {
-        "label": cursor.label,
-        "frame": current_frame
+        label: state.label,
+        frame: current_frame
       };
-      this.highlighted_cell_one = cursor.label;
+      this.highlighted_cell_one = state.label;
       this.highlighted_cell_two = -1;
-      cursor.storedClickX = cursor.imgX;
-      cursor.storedClickY = cursor.imgY;
+      state.storedClickX = state.imgX;
+      state.storedClickY = state.imgY;
     }
   }
 
   handle_mode_prompt_click(evt) {
-    if (this.action === "fill_hole" && cursor.label === 0) {
+    if (this.action === 'fill_hole' && state.label === 0) {
       this.info = {
-        "label": this.info.label,
-        "frame": current_frame,
-        "x_location": cursor.imgX,
-        "y_location": cursor.imgY
+        label: this.info.label,
+        frame: current_frame,
+        x_location: state.imgX,
+        y_location: state.imgY
       };
       action(this.action, this.info);
       this.clear();
-    } else if (this.action === "pick_color"
-          && cursor.label !== 0
-          && cursor.label !== brush.target) {
-      brush.value = cursor.label;
+    } else if (this.action === 'pick_color' && state.label !== 0 &&
+               state.label !== brush.target) {
+      brush.value = state.label;
       if (brush.target !== 0) {
-        this.prompt = "Now drawing over label " + brush.target + " with label " + brush.value
-            + ". Use ESC to leave this mode.";
+        this.prompt = `Now drawing over label ${brush.target} with label ${brush.value}. Use ESC to leave this mode.`;
         this.kind = Modes.drawing;
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       } else {
         this.clear();
       }
-    } else if (this.action === "pick_target" && cursor.label !== 0) {
-      brush.target = cursor.label;
-      this.action = "pick_color";
-      this.prompt = "Click on the label you want to draw with, or press 'n' to draw with an unused label.";
+    } else if (this.action === 'pick_target' && state.label !== 0) {
+      brush.target = state.label;
+      this.action = 'pick_color';
+      this.prompt = 'Click on the label you want to draw with, or press "n" to draw with an unused label.';
       render_info_display();
     }
   }
@@ -545,32 +556,32 @@ class Mode {
     this.kind = Modes.multiple;
 
     this.highlighted_cell_one = this.info.label;
-    this.highlighted_cell_two = cursor.label;
+    this.highlighted_cell_two = state.label;
 
     this.info = {
-      "label_1": this.info.label,
-      "label_2": cursor.label,
-      "frame_1": this.info.frame,
-      "frame_2": current_frame,
-      "x1_location": cursor.storedClickX,
-      "y1_location": cursor.storedClickY,
-      "x2_location": cursor.imgX,
-      "y2_location": cursor.imgY
+      label_1: this.info.label,
+      label_2: state.label,
+      frame_1: this.info.frame,
+      frame_2: current_frame,
+      x1_location: state.storedClickX,
+      y1_location: state.storedClickY,
+      x2_location: state.imgX,
+      y2_location: state.imgY
     };
   }
 
   handle_mode_multiple_click(evt) {
     this.highlighted_cell_one = this.info.label_1;
-    this.highlighted_cell_two = cursor.label;
+    this.highlighted_cell_two = state.label;
     this.info = {
-      "label_1": this.info.label_1,
-      "label_2": cursor.label,
-      "frame_1": this.info.frame_1,
-      "frame_2": current_frame,
-      "x1_location": cursor.storedClickX,
-      "y1_location": cursor.storedClickY,
-      "x2_location": cursor.imgX,
-      "y2_location": cursor.imgY
+      label_1: this.info.label_1,
+      label_2: state.label,
+      frame_1: this.info.frame_1,
+      frame_2: current_frame,
+      x1_location: state.storedClickX,
+      y1_location: state.storedClickY,
+      x2_location: state.imgX,
+      y2_location: state.imgY
     };
   }
 
@@ -581,15 +592,14 @@ class Mode {
     if (this.kind === Modes.prompt) {
       // hole fill or color picking options
       this.handle_mode_prompt_click(evt);
-    } else if (cursor.label === 0) {
+    } else if (state.label === 0) {
       // same as ESC
       this.clear();
-      return; //not sure why we return here
     } else if (this.kind === Modes.none) {
-      //if nothing selected: shift-, alt-, or normal click
+      // if nothing selected: shift-, alt-, or normal click
       this.handle_mode_none_click(evt);
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       } else {
         render_info_display();
       }
@@ -597,7 +607,7 @@ class Mode {
       // one label already selected
       this.handle_mode_single_click(evt);
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       } else {
         render_info_display();
       }
@@ -605,23 +615,23 @@ class Mode {
       // two labels already selected, reselect second label
       this.handle_mode_multiple_click(evt);
       if (current_highlight) {
-        adjuster.preCompAdjust(seg_array, current_highlight, edit_mode, brush, this);
+        adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, this);
       } else {
         render_info_display();
       }
     }
   }
 
-  //shows up in info display as text for "state:"
+  // shows up in info display as text for "state:"
   render() {
     if (this.kind === Modes.none) {
-      return "";
+      return '';
     }
     if (this.kind === Modes.single) {
-      return "SELECTED " + this.info.label;
+      return `SELECTED ${this.info.label}`;
     }
     if (this.kind === Modes.multiple) {
-      return "SELECTED " + this.info.label_1 + ", " + this.info.label_2;
+      return `SELECTED ${this.info.label_1}, ${this.info.label_2}`;
     }
     if (this.kind === Modes.question || this.kind === Modes.prompt || this.kind === Modes.drawing) {
       return this.prompt;
@@ -629,34 +639,24 @@ class Mode {
   }
 }
 
-var Modes = Object.freeze({
-  "none": 1,
-  "single": 2,
-  "multiple": 3,
-  "question": 4,
-  "info": 5,
-  "prompt": 6,
-  "drawing": 7
+const Modes = Object.freeze({
+  none: 1,
+  single: 2,
+  multiple: 3,
+  question: 4,
+  info: 5,
+  prompt: 6,
+  drawing: 7
 });
-
-let rgb;
-
-// dimensions of raw arrays
-let rawWidth;
-let rawHeight;
-
-// TODO: move dimensions into cursor or viewer object?
-// raw image dimensions * screen scaling
-var dimensions;
 
 const padding = 5;
 
-// TODO: this could go into adjuster and cursor classes
-// upon update, not needed by any other objects
-var seg_array; // declare here so it is global var
+const maxLabelsMap = new Map();
+
+let rgb;
 
 var rendering_raw = false;
-let display_labels;
+var display_labels;
 
 var current_frame = 0;
 var current_highlight;
@@ -664,31 +664,90 @@ var max_frames;
 var feature_max;
 var channelMax;
 var tracks;
-let maxLabelsMap = new Map();
 var mode = new Mode(Modes.none, {});
-let edit_mode;
-var answer = "(SPACE=YES / ESC=NO)";
-let spacedown = false;
-var tooltype = 'draw';
+var edit_mode;
+var answer = '(SPACE=YES / ESC=NO)';
 var project_id;
 
-var brush;
-var adjust;
-let cursor;
-let viewer;
+var tracks;
 
-var waitForFinalEvent = (function () {
+var brush;
+var adjuster;
+var cursor;
+var state;
+
+/**
+ * Delays an event callback to prevent calling the callback too frequently.
+ */
+const waitForFinalEvent = (function () {
   var timers = {};
   return function (callback, ms, uniqueId) {
     if (!uniqueId) {
       uniqueId = "Don't call this twice without a uniqueId";
     }
     if (timers[uniqueId]) {
-      clearTimeout (timers[uniqueId]);
+      clearTimeout(timers[uniqueId]);
     }
     timers[uniqueId] = setTimeout(callback, ms);
   };
 })();
+
+/**
+ * Calculate the maximum width of the canvas display area.
+ * The canvas only shares width with the table display on its left.
+ */
+const _calculateMaxWidth = () => {
+  const mainSection = window.getComputedStyle(
+    document.getElementsByTagName('main')[0]
+  );
+  const tableColumn = window.getComputedStyle(
+    document.getElementById('table-col')
+  );
+  const canvasColumn = window.getComputedStyle(
+    document.getElementById('canvas-col')
+  );
+  const maxWidth = Math.floor(
+    document.getElementsByTagName('main')[0].clientWidth -
+    parseInt(mainSection.marginTop) -
+    parseInt(mainSection.marginBottom) -
+    document.getElementById('table-col').clientWidth -
+    parseFloat(tableColumn.paddingLeft) -
+    parseFloat(tableColumn.paddingRight) -
+    parseFloat(tableColumn.marginLeft) -
+    parseFloat(tableColumn.marginRight) -
+    parseFloat(canvasColumn.paddingLeft) -
+    parseFloat(canvasColumn.paddingRight) -
+    parseFloat(canvasColumn.marginLeft) -
+    parseFloat(canvasColumn.marginRight)
+  );
+  return maxWidth;
+}
+
+/**
+ * Calculate the maximum height for the canvas display area,
+ * leaving space for navbar, instructions pane, and footer.
+ */
+const _calculateMaxHeight = () => {
+  const mainSection = window.getComputedStyle(
+    document.getElementsByTagName('main')[0]
+  );
+  // leave space for navbar, instructions pane, and footer
+  const maxHeight = Math.floor(
+    (
+      (
+        window.innerHeight ||
+        document.documentElement.clientHeight ||
+        document.body.clientHeight
+      ) -
+      parseInt(mainSection.marginTop) -
+      parseInt(mainSection.marginBottom) -
+      document.getElementsByClassName('page-footer')[0].clientHeight -
+      document.getElementsByClassName('collapsible')[0].clientHeight -
+      document.getElementsByClassName('navbar-fixed')[0].clientHeight
+    )
+  );
+  return maxHeight;
+}
 
 function upload_file(cb) {
   $.ajax({
@@ -699,96 +758,76 @@ function upload_file(cb) {
   });
 }
 
-// based on dx and dy, update sx and sy
-function panCanvas(dx, dy) {
-  const oldX = viewer.sx;
-  const oldY = viewer.sy;
-  viewer.pan(dx, dy);
-  if (viewer.sx !== oldX || viewer.sy !== oldY) {
-    render_image_display();
-  }
-}
-
 function changeZoom(dzoom) {
-  viewer.changeZoom(dzoom, cursor.canvasPosX, cursor.canvasPosY);
-  updateMousePos(cursor.rawX, cursor.rawY);
+  state.changeZoom(dzoom, state.canvasPosX, state.canvasPosY);
+  updateMousePos(state.rawX, state.rawY);
   render_image_display();
 }
 
 function render_highlight_info() {
+  const highlightText = (current_highlight) ? 'ON' : 'OFF';
+  let currentlyHighlighted = 'none';
   if (current_highlight) {
-    $('#highlight').html("ON");
     if (edit_mode) {
-      if (brush.value > 0) {
-        $('#currently_highlighted').html(brush.value)
-      } else {
-        $('#currently_highlighted').html('-')
-      }
+      currentlyHighlighted = (brush.value > 0) ? brush.value : '-';
     } else {
       if (mode.highlighted_cell_one !== -1) {
         if (mode.highlighted_cell_two !== -1) {
-          $('#currently_highlighted').html(mode.highlighted_cell_one + " , " + mode.highlighted_cell_two);
+          currentlyHighlighted = `${mode.highlighted_cell_one}, ${mode.highlighted_cell_two}`;
         } else {
-          $('#currently_highlighted').html(mode.highlighted_cell_one);
+          currentlyHighlighted = mode.highlighted_cell_one;
         }
-      } else {
-        $('#currently_highlighted').html("none");
       }
     }
-  } else {
-    $('#highlight').html("OFF");
-    $('#currently_highlighted').html("none");
   }
+  document.getElementById('highlight').innerHTML = highlightText;
+  document.getElementById('currently_highlighted').innerHTML = currentlyHighlighted;
 }
 
 function render_edit_info() {
+  const editModeText = (edit_mode) ? 'pixels' : 'whole labels';
+  document.getElementById('edit_mode').innerHTML = editModeText;
+
+  const rowVisibility = (edit_mode) ? 'visible' : 'hidden';
+  document.getElementById('edit_brush_row').style.visibility = rowVisibility;
+  document.getElementById('edit_label_row').style.visibility = rowVisibility;
+  document.getElementById('edit_erase_row').style.visibility = rowVisibility;
+
   if (edit_mode) {
-    $('#edit_mode').html('pixels');
-    $('#edit_brush_row').css('visibility', 'visible');
-    $('#edit_label_row').css('visibility', 'visible');
-    $('#edit_erase_row').css('visibility', 'visible');
+    document.getElementById('edit_brush').innerHTML = brush.size;
 
-    $('#edit_brush').html(brush.size);
-    if (brush.value > 0) {
-      $('#edit_label').html(brush.value);
-    } else {
-      $('#edit_label').html('-');
-    }
+    const editLabelText = (brush.value > 0) ? brush.value : '-';
+    document.getElementById('edit_label').innerHTML = editLabelText;
 
-    if (brush.erase && !brush.conv) {
-      $('#edit_erase').html("ON");
-    } else {
-      $('#edit_erase').html("OFF");
-    }
-
-  } else {
-    $('#edit_mode').html('whole labels');
-    $('#edit_brush_row').css('visibility', 'hidden');
-    $('#edit_label_row').css('visibility', 'hidden');
-    $('#edit_erase_row').css('visibility', 'hidden');
+    const editEraseText = (brush.erase && !brush.conv) ? 'ON' : 'OFF';
+    document.getElementById('edit_erase').innerHTML = editEraseText;
   }
 }
 
 function render_cell_info() {
-  if (cursor.label !== 0) {
-    $('#label').html(cursor.label);
-    let track = tracks[mode.feature][cursor.label.toString()];
-    $('#slices').text(track.slices.toString());
+  if (state.label !== 0) {
+    document.getElementById('label').innerHTML = state.label;
+    const track = tracks[mode.feature][state.label.toString()];
+    document.getElementById('slices').textContent = track.slices.toString();
   } else {
-    $('#label').html("");
-    $('#slices').text("");
+    document.getElementById('label').innerHTML = '';
+    document.getElementById('slices').textContent = '';
   }
 }
 
 // updates html display of side info panel
 function render_info_display() {
   // always show current frame, feature, channel
-  $('#frame').html(current_frame);
-  $('#feature').html(mode.feature);
-  $('#channel').html(mode.channel);
-  $('#zoom').html(`${viewer.zoom}%`);
-  $('#displayedX').html(`${Math.floor(viewer.sx)}-${Math.ceil(viewer.sx+viewer.sWidth)}`);
-  $('#displayedY').html(`${Math.floor(viewer.sy)}-${Math.ceil(viewer.sy+viewer.sHeight)}`);
+  document.getElementById('frame').innerHTML = current_frame;
+  document.getElementById('feature').innerHTML = mode.feature;
+  document.getElementById('channel').innerHTML = mode.channel;
+  document.getElementById('zoom').innerHTML = `${state.zoom}%`;
+
+  const displayedX = `${Math.floor(state.sx)}-${Math.ceil(state.sx + state.sWidth)}`;
+  document.getElementById('displayedX').innerHTML = displayedX;
+
+  const displayedY = `${Math.floor(state.sy)}-${Math.ceil(state.sy + state.sHeight)}`
+  document.getElementById('displayedY').innerHTML = displayedY;
 
   render_highlight_info();
 
@@ -797,70 +836,51 @@ function render_info_display() {
   render_cell_info();
 
   // always show 'state'
-  $('#mode').html(mode.render());
+  document.getElementById('mode').innerHTML = mode.render();
 }
 
-// TODO for ctx.drawImage calls--write a wrapper for these?
-// they all use the same viewer attributes (and padding and dimension args)
-// to use all optional args for ctx.drawImage call
-// possibly a CalibanCanvas class that has ctx, padding, dimensions attributes
 function render_edit_image(ctx) {
   if (rgb && rendering_raw) {
     render_raw_image(ctx);
   } else if (!rgb && !display_labels) {
-    ctx.clearRect(padding, padding, dimensions[0], dimensions[1]);
-    ctx.drawImage(adjuster.preCompRaw,
-                  viewer.sx, viewer.sy,
-                  viewer.sWidth, viewer.sHeight,
-                  padding, padding, dimensions[0], dimensions[1]);
+    this.state.drawImage(ctx, adjuster.preCompRaw, padding);
   } else {
-    ctx.clearRect(padding, padding, dimensions[0], dimensions[1]);
-    ctx.drawImage(adjuster.postCompImg,
-                  viewer.sx, viewer.sy,
-                  viewer.sWidth, viewer.sHeight,
-                  padding, padding, dimensions[0], dimensions[1]);
+    this.state.drawImage(ctx, adjuster.postCompImg, padding);
   }
   ctx.save();
-  let region = new Path2D();
-  region.rect(padding, padding, dimensions[0], dimensions[1]);
+  const region = new Path2D();
+  region.rect(padding, padding, state.scaledWidth, state.scaledHeight);
   ctx.clip(region);
   ctx.imageSmoothingEnabled = true;
 
   // draw brushview on top of cells/annotations
-  brush.draw(ctx, viewer);
+  brush.draw(ctx, state);
 
   ctx.restore();
 }
 
 function render_raw_image(ctx) {
-  ctx.clearRect(padding, padding, dimensions, dimensions[1]);
-  ctx.drawImage(adjuster.contrastedRaw,
-                viewer.sx, viewer.sy,
-                viewer.sWidth, viewer.sHeight,
-                padding, padding, dimensions[0], dimensions[1]);
+  this.state.drawImage(ctx, adjuster.contrastedRaw, padding);
 }
 
 function render_annotation_image(ctx) {
-  ctx.clearRect(padding, padding, dimensions[0], dimensions[1]);
   if (rgb && !display_labels) {
-    ctx.drawImage(adjuster.postCompImg,
-                  viewer.sx, viewer.sy,
-                  viewer.sWidth, viewer.sHeight,
-                  padding, padding, dimensions[0], dimensions[1]);
+    this.state.drawImage(ctx, adjuster.postCompImg, padding);
   } else {
-    ctx.drawImage(adjuster.preCompSeg,
-                  viewer.sx, viewer.sy,
-                  viewer.sWidth, viewer.sHeight,
-                  padding, padding, dimensions[0], dimensions[1]);
+    this.state.drawImage(ctx, adjuster.preCompSeg, padding);
   }
 }
 
 function render_image_display() {
-  let ctx = $('#canvas').get(0).getContext('2d');
+  const ctx = document.getElementById('canvas').getContext('2d');
   ctx.imageSmoothingEnabled = false;
   // TODO: is there a corresponding ctx.restore to match this ctx.save?
   ctx.save();
-  ctx.clearRect(0, 0, 2 * padding + dimensions[0], 2 * padding + dimensions[1]);
+  ctx.clearRect(
+    0, 0,
+    2 * padding + state.scaledWidth,
+    2 * padding + state.scaledHeight
+  );
 
   if (edit_mode) {
     // edit mode (annotations overlaid on raw + brush preview)
@@ -872,22 +892,21 @@ function render_image_display() {
     // draw annotations
     render_annotation_image(ctx);
   }
-  viewer.drawBorders(ctx);
+  state.drawBorders(ctx);
   render_info_display();
 }
 
 function fetch_and_render_frame() {
   $.ajax({
     type: 'GET',
-    url: "frame/" + current_frame + "/" + project_id,
+    url: `frame/${current_frame}/${project_id}`,
     success: function(payload) {
       adjuster.rawLoaded = false;
       adjuster.segLoaded = false;
 
       // load new value of seg_array
       // array of arrays, contains annotation data for frame
-      seg_array = payload.seg_arr;
-      cursor.segArray = seg_array;
+      state.segArray = payload.seg_arr;
       adjuster.segImage.src = payload.segmented;
       adjuster.rawImage.src = payload.raw;
     },
@@ -895,126 +914,65 @@ function fetch_and_render_frame() {
   });
 }
 
-function load_file(file) {
+function loadFile(file, rgb = false, cb) {
   $.ajax({
     type: 'POST',
-    url: `load/${file}?&rgb=${settings.rgb}`,
-    success: function (payload) {
-      max_frames = payload.max_frames;
-      feature_max = payload.feature_max;
-      channelMax = payload.channel_max;
-      rawDimensions = payload.dimensions;
-
-      rawWidth = rawDimensions[0];
-      rawHeight = rawDimensions[1];
-
-      viewer = new CanvasView(width=rawWidth, height=rawHeight);
-
-      // TODO: does this need to be in load_file?
-      // we could probably call it right after load_file to decouple them better
-      setCanvasDimensions(rawDimensions);
-
-      tracks = payload.tracks; // tracks payload is dict
-
-      // for each feature, get list of cell labels that are in that feature
-      // (each is a key in that dict), cast to numbers, then get the maximum
-      // value from each array and store it in a map
-      for (let i = 0; i < Object.keys(tracks).length; i++){
-        let key = Object.keys(tracks)[i]; // the keys are strings
-        if (Object.keys(tracks[key]).length > 0) {
-          // use i as key in this map because it is an int, mode.feature is also int
-          maxLabelsMap.set(i, Math.max(... Object.keys(tracks[key]).map(Number)));
-        } else {
-          // if no labels in feature, explicitly set max label to 0
-          maxLabelsMap.set(i, 0);
-        }
-      }
-      project_id = payload.project_id;
-    },
-    async: false
+    url: `load/${file}?&rgb=${rgb}`,
+    success: cb,
+    async: true
   });
 }
 
+/**
+ * Calculate available space and how much to scale x and y to fill it
+ * @param {*} rawDims the raw dimensions of the input image.
+ */
 function setCanvasDimensions(rawDims) {
-  // calculate available space and how much to scale x and y to fill it
-  // only thing that shares width is the info display on left
-
-  let maxWidth = Math.floor(
-    document.getElementsByTagName('main')[0].clientWidth -
-    parseInt($('main').css('marginTop')) -
-    parseInt($('main').css('marginBottom')) -
-    document.getElementById('table-col').clientWidth -
-    parseFloat($('#table-col').css('padding-left')) -
-    parseFloat($('#table-col').css('padding-right')) -
-    parseFloat($('#table-col').css('margin-left')) -
-    parseFloat($('#table-col').css('margin-right')) -
-    parseFloat($('#canvas-col').css('padding-left')) -
-    parseFloat($('#canvas-col').css('padding-right')) -
-    parseFloat($('#canvas-col').css('margin-left')) -
-    parseFloat($('#canvas-col').css('margin-right'))
-  );
-
-  // leave space for navbar, instructions pane, and footer
-  let maxHeight = Math.floor(
-    (
-      (
-        window.innerHeight ||
-        document.documentElement.clientHeight ||
-        document.body.clientHeight
-      ) -
-      parseInt($('main').css('marginTop')) -
-      parseInt($('main').css('marginBottom')) -
-      document.getElementsByClassName('page-footer')[0].clientHeight -
-      document.getElementsByClassName('collapsible')[0].clientHeight -
-      document.getElementsByClassName('navbar-fixed')[0].clientHeight
-    )
-  );
+  const maxWidth = _calculateMaxWidth()
+  const maxHeight = _calculateMaxHeight()
 
   const scaleX = maxWidth / rawDims[0];
   const scaleY = maxHeight / rawDims[1];
 
   // pick scale that accomodates both dimensions; can be less than 1
   const scale = Math.min(scaleX, scaleY);
-  // dimensions need to maintain aspect ratio for drawing purposes
-  dimensions = [scale * rawDims[0], scale * rawDims[1]];
 
-  viewer.zoom = 100;
-  viewer.scale = scale;
-  viewer.setBorders(padding);
+  state.zoom = 100;
+  state.scale = scale;
+  state.setBorders(padding);
 
   // set canvases size according to scale
-  $('#canvas').get(0).width = dimensions[0] + 2 * padding;
-  $('#canvas').get(0).height = dimensions[1] + 2 * padding;
+  document.getElementById('canvas').width = state.scaledWidth + 2 * padding;
+  document.getElementById('canvas').height = state.scaledHeight + 2 * padding;
 }
 
 // adjust contrast, brightness, or zoom upon mouse scroll
-function handle_scroll(evt) {
+function handleScroll(evt) {
+  const canEdit = (rendering_raw || edit_mode || (rgb && !display_labels));
   if (evt.altKey) {
-    changeZoom(Math.sign(evt.originalEvent.deltaY));
-  } else if ((rendering_raw || edit_mode || (rgb && !display_labels))
-    && !evt.originalEvent.shiftKey) {
-    adjuster.changeContrast(evt.originalEvent.deltaY);
-  } else if ((rendering_raw || edit_mode || (rgb && !display_labels))
-    && evt.originalEvent.shiftKey) {
-    adjuster.changeBrightness(evt.originalEvent.deltaY);
+    changeZoom(Math.sign(evt.deltaY));
+  } else if (canEdit && !evt.shiftKey) {
+    adjuster.changeContrast(evt.deltaY);
+  } else if (canEdit && evt.shiftKey) {
+    adjuster.changeBrightness(evt.deltaY);
   }
 }
 
 // handle pressing mouse button (treats this as the beginning
 // of click&drag, since clicks are handled by Mode.click)
-function handle_mousedown(evt) {
+function handleMousedown(evt) {
+  state.isPressed = true;
   // TODO: refactor "mousedown + mousemove" into ondrag?
-  cursor.pressed = true;
-  if (!spacedown) {
+  if (!state.isSpacedown) {
     if (mode.kind !== Modes.prompt) {
       // begin drawing
       if (edit_mode) {
         if (!brush.show) {
-          brush.threshX = cursor.imgX;
-          brush.threshY = cursor.imgY;
+          brush.threshX = state.imgX;
+          brush.threshY = state.imgY;
         } else if (mode.kind !== Modes.prompt) {
           // not if turning on conv brush
-          cursor.trace.push([cursor.imgY, cursor.imgX]);
+          state.trace.push([state.imgY, state.imgX]);
         }
       }
     }
@@ -1022,10 +980,10 @@ function handle_mousedown(evt) {
 }
 
 function helper_brush_draw() {
-  if (cursor.pressed && !spacedown) {
+  if (state.isCursorPressed() && !state.isSpacedown) {
     // update mouse_trace, but not if turning on conv brush
     if (mode.kind !== Modes.prompt) {
-      cursor.trace.push([cursor.imgY, cursor.imgX]);
+      state.trace.push([state.imgY, state.imgX]);
     }
   } else {
     brush.clearView();
@@ -1035,15 +993,15 @@ function helper_brush_draw() {
 
 // input will typically be evt.offsetX, evt.offsetY (mouse events)
 function updateMousePos(x, y) {
-  const oldImgX = cursor.imgX;
-  const oldImgY = cursor.imgY;
+  const oldImgX = state.imgX;
+  const oldImgY = state.imgY;
 
-  cursor.updatePos(x, y, padding, viewer);
+  state.updateCursorPosition(x, y, padding);
 
   // if cursor has actually changed location in image
-  if (oldImgX !== cursor.imgX || oldImgY !== cursor.imgY) {
-    brush.x = cursor.imgX;
-    brush.y = cursor.imgY;
+  if (oldImgX !== state.imgX || oldImgY !== state.imgY) {
+    brush.x = state.imgX;
+    brush.y = state.imgY;
     // update brush preview
     if (edit_mode) {
       // brush's canvas is keeping track of the brush
@@ -1058,73 +1016,38 @@ function updateMousePos(x, y) {
 }
 
 // handles mouse movement, whether or not mouse button is held down
-function handle_mousemove(evt) {
-  if (cursor.pressed && spacedown) {
-    panCanvas(
-      evt.originalEvent.movementX * 100 / (viewer.zoom * viewer.scale),
-      evt.originalEvent.movementY * 100 / (viewer.zoom * viewer.scale)
-    );
+function handleMousemove(evt) {
+  if (state.isCursorPressed() && state.isSpacedown) {
+    // get the old values to see if rendering is reqiured.
+    const oldX = state.sx;
+    const oldY = state.sy;
+
+    const zoom = 100 / (state.zoom * state.scale)
+    state.pan(evt.movementX * zoom, evt.movementY * zoom);
+
+    if (state.sx !== oldX || state.sy !== oldY) {
+      render_image_display();
+    }
   }
-
   updateMousePos(evt.offsetX, evt.offsetY);
-
-  render_info_display();
 }
 
 // handles end of click&drag (different from click())
-function handle_mouseup() {
-  cursor.pressed = false;
-  if (!spacedown) {
+function handleMouseup() {
+  state.isPressed = false;
+  if (!state.isSpacedown) {
     if (mode.kind !== Modes.prompt) {
       if (edit_mode) {
         if (!brush.show) {
           mode.handle_threshold();
         } else {
-          //send click&drag coordinates to caliban.py to update annotations
+          // send click&drag coordinates to caliban.py to update annotations
           mode.handle_draw();
         }
         brush.refreshView();
       }
     }
   }
-}
-
-function prepare_canvas() {
-  // bind click on canvas
-  $('#canvas').click(function(evt) {
-    if (!spacedown && (!edit_mode || mode.kind === Modes.prompt)) {
-      mode.click(evt);
-    }
-  });
-  // bind scroll wheel
-  $('#canvas').on('wheel', function(evt) {
-    // adjusts contrast of raw when scrolled
-    handle_scroll(evt);
-  });
-  // mousedown for click&drag/handle_draw DIFFERENT FROM CLICK
-  $('#canvas').mousedown(function(evt) {
-    handle_mousedown(evt);
-  });
-  // bind mouse movement
-  $('#canvas').mousemove(function(evt) {
-    // handle brush preview
-    handle_mousemove(evt);
-  });
-  // mouse button release (end of click&drag) bound to document, not just canvas
-  // bind keypress
-  window.addEventListener('keydown', function(evt) {
-    mode.handle_key(evt.key);
-  }, false);
-  window.addEventListener('keydown', function(evt) {
-    if (evt.key === ' ') {
-      spacedown = true;
-    }
-  }, false);
-  window.addEventListener('keyup', function(evt) {
-    if (evt.key === ' ') {
-      spacedown = false;
-    }
-  }, false);
 }
 
 function action(action, info, frame = current_frame) {
@@ -1139,17 +1062,16 @@ function action(action, info, frame = current_frame) {
       if (payload.imgs) {
         // load new value of seg_array
         // array of arrays, contains annotation data for frame
-        if (payload.imgs.hasOwnProperty('seg_arr')) {
-          seg_array = payload.imgs.seg_arr;
-          cursor.segArray = seg_array;
+        if (Object.prototype.hasOwnProperty.call(payload.imgs, 'seg_arr')) {
+          state.segArray = payload.imgs.seg_arr;
         }
 
-        if (payload.imgs.hasOwnProperty('segmented')) {
+        if (Object.prototype.hasOwnProperty.call(payload.imgs, 'segmented')) {
           adjuster.segLoaded = false;
           adjuster.segImage.src = payload.imgs.segmented;
         }
 
-        if (payload.imgs.hasOwnProperty('raw')) {
+        if (Object.prototype.hasOwnProperty.call(payload.imgs, 'raw')) {
           adjuster.rawLoaded = false;
           adjuster.rawImage.src = payload.imgs.raw;
         }
@@ -1157,11 +1079,11 @@ function action(action, info, frame = current_frame) {
       if (payload.tracks) {
         tracks = payload.tracks;
         // update maxLabelsMap when we get new track info
-        for (let i = 0; i < Object.keys(tracks).length; i++){
-          let key = Object.keys(tracks)[i]; // the keys are strings
+        for (let i = 0; i < Object.keys(tracks).length; i++) {
+          const key = Object.keys(tracks)[i]; // the keys are strings
           if (Object.keys(tracks[key]).length > 0) {
             // use i as key in this map because it is an int, mode.feature is also int
-            maxLabelsMap.set(i, Math.max(... Object.keys(tracks[key]).map(Number)));
+            maxLabelsMap.set(i, Math.max(...Object.keys(tracks[key]).map(Number)));
           } else {
             // if no labels in feature, explicitly set max label to 0
             maxLabelsMap.set(i, 0);
@@ -1176,26 +1098,19 @@ function action(action, info, frame = current_frame) {
   });
 }
 
-function start_caliban(filename) {
-  if (settings.pixel_only && !settings.label_only) {
-    edit_mode = true;
-  } else {
-    edit_mode = false;
-  }
+function startCaliban(filename, settings) {
   rgb = settings.rgb;
-  if (rgb) {
-    current_highlight = true;
-    display_labels = false;
-  } else {
-    current_highlight = false;
-    display_labels = true;
-  }
+  current_highlight = settings.rgb;
+  display_labels = !settings.rgb;
+  edit_mode = (settings.pixel_only && !settings.label_only);
+
   // disable scrolling from scrolling around on page (it should just control brightness)
-  document.addEventListener('wheel', function(event) {
+  document.addEventListener('wheel', (event) => {
     event.preventDefault();
-  }, {passive: false});
+  }, { passive: false });
+
   // disable space and up/down keys from moving around on page
-  $(document).on('keydown', function(event) {
+  document.addEventListener('keydown', (event) => {
     if (event.key === ' ') {
       event.preventDefault();
     } else if (event.key === 'ArrowUp') {
@@ -1205,32 +1120,97 @@ function start_caliban(filename) {
     }
   });
 
-  // resize the canvas every time the window is resized
-  $(window).resize(function () {
-    waitForFinalEvent(function() {
-      mode.clear();
-      setCanvasDimensions(rawDimensions);
-      cursor.scale = viewer.scale;
-      brush.refreshView();
-    }, 500, 'canvasResize');
+  loadFile(filename, settings.rgb, (payload) => {
+    max_frames = payload.max_frames;
+    feature_max = payload.feature_max;
+    channelMax = payload.channel_max;
+    project_id = payload.project_id;
+
+    const rawWidth = payload.dimensions[0];
+    const rawHeight = payload.dimensions[1];
+
+    state = new CanvasState(rawWidth, rawHeight, 1, padding);
+
+    window.addEventListener('keydown', (e) => {
+      if (e.key === ' ') {
+        state.isSpacedown = true;
+      }
+    }, false);
+    window.addEventListener('keyup', (e) => {
+      if (e.key === ' ') {
+        state.isSpacedown = false;
+      }
+    }, false);
+
+    tracks = payload.tracks; // tracks payload is dict
+
+    // for each feature, get list of cell labels that are in that feature
+    // (each is a key in that dict), cast to numbers, then get the maximum
+    // value from each array and store it in a map
+    for (let i = 0; i < Object.keys(tracks).length; i++) {
+      const key = Object.keys(tracks)[i]; // the keys are strings
+      if (Object.keys(tracks[key]).length > 0) {
+        // use i as key in this map because it is an int, mode.feature is also int
+        maxLabelsMap.set(i, Math.max(...Object.keys(tracks[key]).map(Number)));
+      } else {
+        // if no labels in feature, explicitly set max label to 0
+        maxLabelsMap.set(i, 0);
+      }
+    }
+
+    brush = new Brush(rawHeight, rawWidth, padding);
+
+    // define image onload cascade behavior, need rawHeight and rawWidth first
+    adjuster = new ImageAdjuster(rawWidth, rawHeight, rgb, channelMax);
+
+    adjuster.rawImage.onload = () => adjuster.contrastRaw();
+    adjuster.segImage.onload = () => adjuster.preCompAdjust(state.segArray, current_highlight, edit_mode, brush, mode);
+    if (rgb) {
+      adjuster.contrastedRaw.onload = () => adjuster.rawAdjust(state.segArray, current_highlight, edit_mode, brush, mode);
+      adjuster.preCompSeg.onload = () => adjuster.segAdjust(state.segArray, current_highlight, edit_mode, brush, mode);
+    } else {
+      adjuster.contrastedRaw.onload = () => adjuster.preCompRawAdjust();
+      adjuster.preCompRaw.onload = () => adjuster.rawAdjust(state.segArray, current_highlight, edit_mode, brush, mode);
+      adjuster.preCompSeg.onload = () => adjuster.segAdjust(state.segArray, current_highlight, edit_mode, brush, mode);
+      adjuster.compositedImg.onload = () => adjuster.postCompAdjust(state.segArray, edit_mode, brush);
+    }
+
+    adjuster.postCompImg.onload = render_image_display;
+
+    document.addEventListener('mouseup', (e) => handleMouseup(e));
+
+    setCanvasDimensions(payload.dimensions);
+
+    // resize the canvas every time the window is resized
+    window.addEventListener('resize', function() {
+      waitForFinalEvent(() => {
+        mode.clear();
+        setCanvasDimensions(payload.dimensions);
+        brush.refreshView();
+      }, 500, 'canvasResize');
+    });
+
+    window.addEventListener('keydown', (evt) => {
+      mode.handle_key(evt.key);
+    }, false);
+
+    const canvasElement = document.getElementById('canvas');
+    // bind click on canvas
+    canvasElement.addEventListener('click', (evt) => {
+      if (!state.isSpacedown && (!edit_mode || mode.kind === Modes.prompt)) {
+        mode.click(evt);
+      }
+    });
+
+    // bind scroll wheel, change contrast of raw when scrolled
+    canvasElement.addEventListener('wheel', (e) => handleScroll(e));
+
+    // mousedown for click&drag/handle_draw DIFFERENT FROM CLICK
+    canvasElement.addEventListener('mousedown', (e) => handleMousedown(e));
+
+    // bind mouse movement
+    canvasElement.addEventListener('mousemove', (e) => handleMousemove(e));
+
+    fetch_and_render_frame();
   });
-
-  document.addEventListener('mouseup', function() {
-    handle_mouseup();
-   });
-
-  load_file(filename);
-
-  cursor = new CalibanCursor(width=rawWidth, height=rawHeight, scale=viewer.scale);
-
-  // define image onload cascade behavior, need rawHeight and rawWidth first
-  adjuster = new ImageAdjuster(width=rawWidth, height=rawHeight,
-                               rgb=rgb, channelMax=channelMax);
-  brush = new Brush(height=rawHeight, width=rawWidth, pad=padding);
-
-  adjuster.postCompImg.onload = render_image_display;
-
-  prepare_canvas();
-  fetch_and_render_frame();
-
 }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -640,9 +640,6 @@ let rawHeight;
 const padding = 5;
 
 // mouse position variables
-// mouse position on canvas, no adjustment for padding
-let _rawMouseX;
-let _rawMouseY;
 // adjusted for padding
 let canvasPosX;
 let canvasPosY;
@@ -713,7 +710,7 @@ function panCanvas(dx, dy) {
 
 function changeZoom(dzoom) {
   viewer.changeZoom(dzoom, canvasPosX, canvasPosY);
-  updateMousePos(_rawMouseX, _rawMouseY);
+  updateMousePos(cursor.rawX, cursor.rawY);
   render_image_display();
 }
 
@@ -1048,8 +1045,8 @@ function updateMousePos(x, y) {
   // update brush if these have changed
 
   // store raw mouse position, in case of pan without mouse movement
-  _rawMouseX = x;
-  _rawMouseY = y;
+  cursor.rawX = x;
+  cursor.rawY = y;
 
   // convert to viewing pane position, to check whether to access label underneath
   canvasPosX = x - padding;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1308,6 +1308,7 @@ function start_caliban(filename) {
     waitForFinalEvent(function() {
       mode.clear();
       setCanvasDimensions(rawDimensions);
+      brush.scale = scale;
       cursor.scale = scale;
       brush.refreshView();
     }, 500, 'canvasResize');

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -689,7 +689,6 @@ let maxLabelsMap = new Map();
 var mode = new Mode(Modes.none, {});
 let edit_mode;
 var answer = "(SPACE=YES / ESC=NO)";
-let mousedown = false;
 let spacedown = false;
 var tooltype = 'draw';
 var project_id;
@@ -697,6 +696,7 @@ let mouse_trace = [];
 
 var brush;
 var adjust;
+let cursor;
 
 var waitForFinalEvent = (function () {
   var timers = {};
@@ -1118,7 +1118,7 @@ function handle_scroll(evt) {
 // of click&drag, since clicks are handled by Mode.click)
 function handle_mousedown(evt) {
   // TODO: refactor "mousedown + mousemove" into ondrag?
-  mousedown = true;
+  cursor.pressed = true;
   if (!spacedown) {
     if (mode.kind !== Modes.prompt) {
       // begin drawing
@@ -1136,7 +1136,7 @@ function handle_mousedown(evt) {
 }
 
 function helper_brush_draw() {
-  if (mousedown && !spacedown) {
+  if (cursor.pressed && !spacedown) {
     // update mouse_trace, but not if turning on conv brush
     if (mode.kind !== Modes.prompt) {
       mouse_trace.push([imgY, imgX]);
@@ -1178,7 +1178,7 @@ function updateMousePos(x, y) {
 
 // handles mouse movement, whether or not mouse button is held down
 function handle_mousemove(evt) {
-  if (spacedown && mousedown) {
+  if (cursor.pressed && spacedown) {
     panCanvas(
       evt.originalEvent.movementX * 100 / (zoom * scale),
       evt.originalEvent.movementY * 100 / (zoom * scale)
@@ -1192,7 +1192,7 @@ function handle_mousemove(evt) {
 
 // handles end of click&drag (different from click())
 function handle_mouseup() {
-  mousedown = false;
+  cursor.pressed = false;
   if (!spacedown) {
     if (mode.kind !== Modes.prompt) {
       if (edit_mode) {
@@ -1337,6 +1337,8 @@ function start_caliban(filename) {
    });
 
   load_file(filename);
+
+  cursor = new CalibanCursor();
 
   // define image onload cascade behavior, need rawHeight and rawWidth first
   adjuster = new ImageAdjuster(width=rawWidth, height=rawHeight,

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -501,8 +501,8 @@ class Mode {
       };
       this.highlighted_cell_one = current_label;
       this.highlighted_cell_two = -1;
-      storedClickX = cursor.imgX;
-      storedClickY = cursor.imgY;
+      cursor.storedClickX = cursor.imgX;
+      cursor.storedClickY = cursor.imgY;
     }
   }
 
@@ -547,8 +547,8 @@ class Mode {
       "label_2": current_label,
       "frame_1": this.info.frame,
       "frame_2": current_frame,
-      "x1_location": storedClickX,
-      "y1_location": storedClickY,
+      "x1_location": cursor.storedClickX,
+      "y1_location": cursor.storedClickY,
       "x2_location": cursor.imgX,
       "y2_location": cursor.imgY
     };
@@ -562,8 +562,8 @@ class Mode {
       "label_2": current_label,
       "frame_1": this.info.frame_1,
       "frame_2": current_frame,
-      "x1_location": storedClickX,
-      "y1_location": storedClickY,
+      "x1_location": cursor.storedClickX,
+      "y1_location": cursor.storedClickY,
       "x2_location": cursor.imgX,
       "y2_location": cursor.imgY
     };
@@ -638,11 +638,6 @@ let rawWidth;
 let rawHeight;
 
 const padding = 5;
-
-// mouse position variables
-// in original image coords
-let storedClickX;
-let storedClickY;
 
 var seg_array; // declare here so it is global var
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1317,6 +1317,7 @@ function start_caliban(filename) {
     waitForFinalEvent(function() {
       mode.clear();
       setCanvasDimensions(rawDimensions);
+      cursor.scale = scale;
       brush.refreshView();
     }, 500, 'canvasResize');
   });
@@ -1327,7 +1328,7 @@ function start_caliban(filename) {
 
   load_file(filename);
 
-  cursor = new CalibanCursor();
+  cursor = new CalibanCursor(width=rawWidth, height=rawHeight, scale=scale);
   viewer = new CanvasView(width=rawWidth, height=rawHeight);
 
   // define image onload cascade behavior, need rawHeight and rawWidth first

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -476,33 +476,33 @@ class Mode {
       this.kind = Modes.question;
       this.action = "flood_contiguous";
       this.info = {
-        "label": current_label,
+        "label": cursor.label,
         "frame": current_frame,
         "x_location": cursor.imgX,
         "y_location": cursor.imgY
       };
       this.prompt = "SPACE = FLOOD SELECTED CELL WITH NEW LABEL / ESC = CANCEL";
-      this.highlighted_cell_one = current_label;
+      this.highlighted_cell_one = cursor.label;
     } else if (evt.shiftKey) {
       // shift+click
       this.kind = Modes.question;
       this.action = "trim_pixels";
       this.info = {
-        "label": current_label,
+        "label": cursor.label,
         "frame": current_frame,
         "x_location": cursor.imgX,
         "y_location": cursor.imgY
       };
       this.prompt = "SPACE = TRIM DISCONTIGUOUS PIXELS FROM CELL / ESC = CANCEL";
-      this.highlighted_cell_one = current_label;
+      this.highlighted_cell_one = cursor.label;
     } else {
       // normal click
       this.kind = Modes.single;
       this.info = {
-        "label": current_label,
+        "label": cursor.label,
         "frame": current_frame
       };
-      this.highlighted_cell_one = current_label;
+      this.highlighted_cell_one = cursor.label;
       this.highlighted_cell_two = -1;
       cursor.storedClickX = cursor.imgX;
       cursor.storedClickY = cursor.imgY;
@@ -510,7 +510,7 @@ class Mode {
   }
 
   handle_mode_prompt_click(evt) {
-    if (this.action === "fill_hole" && current_label === 0) {
+    if (this.action === "fill_hole" && cursor.label === 0) {
       this.info = {
         "label": this.info.label,
         "frame": current_frame,
@@ -520,9 +520,9 @@ class Mode {
       action(this.action, this.info);
       this.clear();
     } else if (this.action === "pick_color"
-          && current_label !== 0
-          && current_label !== brush.target) {
-      brush.value = current_label;
+          && cursor.label !== 0
+          && cursor.label !== brush.target) {
+      brush.value = cursor.label;
       if (brush.target !== 0) {
         this.prompt = "Now drawing over label " + brush.target + " with label " + brush.value
             + ". Use ESC to leave this mode.";
@@ -531,8 +531,8 @@ class Mode {
       } else {
         this.clear();
       }
-    } else if (this.action === "pick_target" && current_label !== 0) {
-      brush.target = current_label;
+    } else if (this.action === "pick_target" && cursor.label !== 0) {
+      brush.target = cursor.label;
       this.action = "pick_color";
       this.prompt = "Click on the label you want to draw with, or press 'n' to draw with an unused label.";
       render_info_display();
@@ -545,11 +545,11 @@ class Mode {
     this.kind = Modes.multiple;
 
     this.highlighted_cell_one = this.info.label;
-    this.highlighted_cell_two = current_label;
+    this.highlighted_cell_two = cursor.label;
 
     this.info = {
       "label_1": this.info.label,
-      "label_2": current_label,
+      "label_2": cursor.label,
       "frame_1": this.info.frame,
       "frame_2": current_frame,
       "x1_location": cursor.storedClickX,
@@ -561,10 +561,10 @@ class Mode {
 
   handle_mode_multiple_click(evt) {
     this.highlighted_cell_one = this.info.label_1;
-    this.highlighted_cell_two = current_label;
+    this.highlighted_cell_two = cursor.label;
     this.info = {
       "label_1": this.info.label_1,
-      "label_2": current_label,
+      "label_2": cursor.label,
       "frame_1": this.info.frame_1,
       "frame_2": current_frame,
       "x1_location": cursor.storedClickX,
@@ -581,7 +581,7 @@ class Mode {
     if (this.kind === Modes.prompt) {
       // hole fill or color picking options
       this.handle_mode_prompt_click(evt);
-    } else if (current_label === 0) {
+    } else if (cursor.label === 0) {
       // same as ESC
       this.clear();
       return; //not sure why we return here
@@ -659,7 +659,6 @@ var rendering_raw = false;
 let display_labels;
 
 var current_frame = 0;
-var current_label = 0;
 var current_highlight;
 var max_frames;
 var feature_max;
@@ -771,13 +770,9 @@ function render_edit_info() {
 }
 
 function render_cell_info() {
-  // TODO: could also change to add seg_array as attribute of cursor object
-  // so that current_label becomes cursor.label and is updated on mouse movement,
-  // cursor.seg_array updated on new seg_array being loaded
-  current_label = cursor.getCurrentLabel();
-  if (current_label !== 0) {
-    $('#label').html(current_label);
-    let track = tracks[mode.feature][current_label.toString()];
+  if (cursor.label !== 0) {
+    $('#label').html(cursor.label);
+    let track = tracks[mode.feature][cursor.label.toString()];
     $('#slices').text(track.slices.toString());
   } else {
     $('#label').html("");

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -859,7 +859,7 @@ function render_edit_image(ctx) {
   ctx.imageSmoothingEnabled = true;
 
   // draw brushview on top of cells/annotations
-  brush.draw(ctx, viewer.sx, viewer.sy, viewer.sWidth, viewer.sHeight, viewer.scale*viewer.zoom/100);
+  brush.draw(ctx, viewer);
 
   ctx.restore();
 }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -655,11 +655,6 @@ let storedClickY;
 
 var seg_array; // declare here so it is global var
 
-let topBorder = new Path2D();
-let bottomBorder = new Path2D();
-let rightBorder = new Path2D();
-let leftBorder = new Path2D();
-
 var rendering_raw = false;
 let display_labels;
 
@@ -887,43 +882,6 @@ function render_annotation_image(ctx) {
   }
 }
 
-function drawBorders(ctx) {
-  ctx.save();
-  // left border
-  if (Math.floor(viewer.sx) === 0) {
-    ctx.fillStyle = 'white';
-  } else {
-    ctx.fillStyle = 'black';
-  }
-  ctx.fill(leftBorder);
-
-  // right border
-  if (Math.ceil(viewer.sx + viewer.sWidth) === rawWidth) {
-    ctx.fillStyle = 'white';
-  } else {
-    ctx.fillStyle = 'black';
-  }
-  ctx.fill(rightBorder);
-
-  // top border
-  if (Math.floor(viewer.sy) === 0) {
-    ctx.fillStyle = 'white';
-  } else {
-    ctx.fillStyle = 'black';
-  }
-  ctx.fill(topBorder);
-
-  // bottom border
-  if (Math.ceil(viewer.sy + viewer.sHeight) === rawHeight) {
-    ctx.fillStyle = 'white';
-  } else {
-    ctx.fillStyle = 'black';
-  }
-  ctx.fill(bottomBorder);
-
-  ctx.restore();
-}
-
 function render_image_display() {
   let ctx = $('#canvas').get(0).getContext('2d');
   ctx.imageSmoothingEnabled = false;
@@ -940,7 +898,7 @@ function render_image_display() {
     // draw annotations
     render_annotation_image(ctx);
   }
-  drawBorders(ctx);
+  viewer.drawBorders(ctx);
   render_info_display();
 }
 
@@ -1045,39 +1003,11 @@ function setCanvasDimensions(rawDims) {
 
   viewer.zoom = 100;
   viewer.scale = scale;
+  viewer.setBorders(padding);
 
   // set canvases size according to scale
   $('#canvas').get(0).width = dimensions[0] + 2 * padding;
   $('#canvas').get(0).height = dimensions[1] + 2 * padding;
-
-  // create paths for recoloring borders
-  topBorder = new Path2D();
-  topBorder.moveTo(0, 0);
-  topBorder.lineTo(padding, padding);
-  topBorder.lineTo(dimensions[0] + padding, padding);
-  topBorder.lineTo(dimensions[0] + 2 * padding, 0);
-  topBorder.closePath();
-
-  bottomBorder = new Path2D();
-  bottomBorder.moveTo(0, dimensions[1] + 2 * padding);
-  bottomBorder.lineTo(padding, dimensions[1] + padding);
-  bottomBorder.lineTo(dimensions[0] + padding, dimensions[1] + padding);
-  bottomBorder.lineTo(dimensions[0] + 2 * padding, dimensions[1] + 2 * padding);
-  bottomBorder.closePath();
-
-  leftBorder = new Path2D();
-  leftBorder.moveTo(0, 0);
-  leftBorder.lineTo(0, dimensions[1] + 2 * padding);
-  leftBorder.lineTo(padding, dimensions[1] + padding);
-  leftBorder.lineTo(padding, padding);
-  leftBorder.closePath();
-
-  rightBorder = new Path2D();
-  rightBorder.moveTo(dimensions[0] + 2 * padding, 0);
-  rightBorder.lineTo(dimensions[0] + padding, padding);
-  rightBorder.lineTo(dimensions[0] + padding, dimensions[1] + padding);
-  rightBorder.lineTo(dimensions[0] + 2 * padding, dimensions[1] + 2 * padding);
-  rightBorder.closePath();
 }
 
 // adjust contrast, brightness, or zoom upon mouse scroll

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -656,8 +656,6 @@ let storedClickY;
 
 // zoom, starts at 100 percent (value set in ___)
 let zoom;
-// farthest amount to zoom out
-let zoomLimit;
 
 var seg_array; // declare here so it is global var
 
@@ -730,7 +728,7 @@ function changeZoom(dzoom) {
   let newWidth = rawWidth*100/newZoom;
   let oldHeight = viewer.sHeight;
   let oldWidth = viewer.sWidth;
-  if (newZoom >= zoomLimit) {
+  if (newZoom >= viewer.zoomLimit) {
     zoom = newZoom;
     viewer.sHeight = newHeight;
     viewer.sWidth = newWidth;
@@ -1058,7 +1056,6 @@ function setCanvasDimensions(rawDims) {
   dimensions = [scale * rawDims[0], scale * rawDims[1]];
 
   zoom = 100;
-  zoomLimit = 100;
 
   // set canvases size according to scale
   $('#canvas').get(0).width = dimensions[0] + 2 * padding;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -428,8 +428,8 @@ class Mode {
   handle_threshold() {
     let threshold_start_y = brush.threshY;
     let threshold_start_x = brush.threshX;
-    let threshold_end_x = imgX;
-    let threshold_end_y = imgY;
+    let threshold_end_x = cursor.imgX;
+    let threshold_end_y = cursor.imgY;
 
     if (threshold_start_y !== threshold_end_y &&
         threshold_start_x !== threshold_end_x) {
@@ -475,8 +475,8 @@ class Mode {
       this.info = {
         "label": current_label,
         "frame": current_frame,
-        "x_location": imgX,
-        "y_location": imgY
+        "x_location": cursor.imgX,
+        "y_location": cursor.imgY
       };
       this.prompt = "SPACE = FLOOD SELECTED CELL WITH NEW LABEL / ESC = CANCEL";
       this.highlighted_cell_one = current_label;
@@ -487,8 +487,8 @@ class Mode {
       this.info = {
         "label": current_label,
         "frame": current_frame,
-        "x_location": imgX,
-        "y_location": imgY
+        "x_location": cursor.imgX,
+        "y_location": cursor.imgY
       };
       this.prompt = "SPACE = TRIM DISCONTIGUOUS PIXELS FROM CELL / ESC = CANCEL";
       this.highlighted_cell_one = current_label;
@@ -501,8 +501,8 @@ class Mode {
       };
       this.highlighted_cell_one = current_label;
       this.highlighted_cell_two = -1;
-      storedClickX = imgX;
-      storedClickY = imgY;
+      storedClickX = cursor.imgX;
+      storedClickY = cursor.imgY;
     }
   }
 
@@ -511,8 +511,8 @@ class Mode {
       this.info = {
         "label": this.info.label,
         "frame": current_frame,
-        "x_location": imgX,
-        "y_location": imgY
+        "x_location": cursor.imgX,
+        "y_location": cursor.imgY
       };
       action(this.action, this.info);
       this.clear();
@@ -549,8 +549,8 @@ class Mode {
       "frame_2": current_frame,
       "x1_location": storedClickX,
       "y1_location": storedClickY,
-      "x2_location": imgX,
-      "y2_location": imgY
+      "x2_location": cursor.imgX,
+      "y2_location": cursor.imgY
     };
   }
 
@@ -564,8 +564,8 @@ class Mode {
       "frame_2": current_frame,
       "x1_location": storedClickX,
       "y1_location": storedClickY,
-      "x2_location": imgX,
-      "y2_location": imgY
+      "x2_location": cursor.imgX,
+      "y2_location": cursor.imgY
     };
   }
 
@@ -640,9 +640,6 @@ let rawHeight;
 const padding = 5;
 
 // mouse position variables
-// coordinates in original image (used for actions, labels, etc)
-let imgX;
-let imgY;
 // in original image coords
 let storedClickX;
 let storedClickY;
@@ -715,7 +712,7 @@ function changeZoom(dzoom) {
 function label_under_mouse() {
   let new_label;
   if (cursor.inRange()) {
-    new_label = Math.abs(seg_array[imgY][imgX]); //check array value at mouse location
+    new_label = Math.abs(seg_array[cursor.imgY][cursor.imgX]); //check array value at mouse location
   } else {
     new_label = 0;
   }
@@ -1010,11 +1007,11 @@ function handle_mousedown(evt) {
       // begin drawing
       if (edit_mode) {
         if (!brush.show) {
-          brush.threshX = imgX;
-          brush.threshY = imgY;
+          brush.threshX = cursor.imgX;
+          brush.threshY = cursor.imgY;
         } else if (mode.kind !== Modes.prompt) {
           // not if turning on conv brush
-          cursor.trace.push([imgY, imgX]);
+          cursor.trace.push([cursor.imgY, cursor.imgX]);
         }
       }
     }
@@ -1025,7 +1022,7 @@ function helper_brush_draw() {
   if (cursor.pressed && !spacedown) {
     // update mouse_trace, but not if turning on conv brush
     if (mode.kind !== Modes.prompt) {
-      cursor.trace.push([imgY, imgX]);
+      cursor.trace.push([cursor.imgY, cursor.imgX]);
     }
   } else {
     brush.clearView();
@@ -1035,26 +1032,15 @@ function helper_brush_draw() {
 
 // input will typically be evt.offsetX, evt.offsetY (mouse events)
 function updateMousePos(x, y) {
+  const oldImgX = cursor.imgX;
+  const oldImgY = cursor.imgY;
 
-  // get old imgX and imgY
-  // run cursor.updatePos(x, y, viewer)
-  // check new imgX and imgY
-  // update brush if these have changed
+  cursor.updatePos(x, y, padding, viewer);
 
-  // store raw mouse position, in case of pan without mouse movement
-  cursor.rawX = x;
-  cursor.rawY = y;
-
-  // convert to viewing pane position, to check whether to access label underneath
-  cursor.canvasPosX = x - padding;
-  cursor.canvasPosY = y - padding;
-
-  // convert to image indices, to use for actions and getting label
-  if (cursor.inRange()) {
-    imgX = Math.floor((cursor.canvasPosX * 100 / (viewer.scale * viewer.zoom) + viewer.sx));
-    imgY = Math.floor((cursor.canvasPosY * 100 / (viewer.scale * viewer.zoom) + viewer.sy));
-    brush.x = imgX;
-    brush.y = imgY;
+  // if cursor has actually changed location in image
+  if (oldImgX !== cursor.imgX || oldImgY !== cursor.imgY) {
+    brush.x = cursor.imgX;
+    brush.y = cursor.imgY;
     // update brush preview
     if (edit_mode) {
       // brush's canvas is keeping track of the brush

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -714,7 +714,7 @@ function changeZoom(dzoom) {
 
 function label_under_mouse() {
   let new_label;
-  if (cursor.inRange(cursor.canvasPosX, cursor.canvasPosY)) {
+  if (cursor.inRange()) {
     new_label = Math.abs(seg_array[imgY][imgX]); //check array value at mouse location
   } else {
     new_label = 0;
@@ -1050,7 +1050,7 @@ function updateMousePos(x, y) {
   cursor.canvasPosY = y - padding;
 
   // convert to image indices, to use for actions and getting label
-  if (cursor.inRange(cursor.canvasPosX, cursor.canvasPosY)) {
+  if (cursor.inRange()) {
     imgX = Math.floor((cursor.canvasPosX * 100 / (viewer.scale * viewer.zoom) + viewer.sx));
     imgY = Math.floor((cursor.canvasPosY * 100 / (viewer.scale * viewer.zoom) + viewer.sy));
     brush.x = imgX;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -743,19 +743,10 @@ function changeZoom(dzoom) {
   render_image_display();
 }
 
-// check if the mouse position in canvas matches to a displayed part of image
-function inRange(x, y) {
-  if (x >= 0 && x < dimensions[0] &&
-      y >= 0 && y < dimensions[1]) {
-    return true;
-  } else {
-    return false;
-  }
-}
 
 function label_under_mouse() {
   let new_label;
-  if (inRange(canvasPosX, canvasPosY)) {
+  if (cursor.inRange(canvasPosX, canvasPosY)) {
     new_label = Math.abs(seg_array[imgY][imgX]); //check array value at mouse location
   } else {
     new_label = 0;
@@ -1147,7 +1138,7 @@ function updateMousePos(x, y) {
   canvasPosY = y - padding;
 
   // convert to image indices, to use for actions and getting label
-  if (inRange(canvasPosX, canvasPosY)) {
+  if (cursor.inRange(canvasPosX, canvasPosY)) {
     imgX = Math.floor((canvasPosX * 100 / (scale * zoom) + viewer.sx));
     imgY = Math.floor((canvasPosY * 100 / (scale * zoom) + viewer.sy));
     brush.x = imgX;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -654,9 +654,6 @@ let imgY;
 let storedClickX;
 let storedClickY;
 
-// zoom, starts at 100 percent (value set in ___)
-let zoom;
-
 var seg_array; // declare here so it is global var
 
 let topBorder = new Path2D();
@@ -721,14 +718,14 @@ function panCanvas(dx, dy) {
 }
 
 function changeZoom(dzoom) {
-  let newZoom = zoom - 10*dzoom;
-  let oldZoom = zoom;
-  let newHeight = rawHeight*100/newZoom;
-  let newWidth = rawWidth*100/newZoom;
-  let oldHeight = viewer.sHeight;
-  let oldWidth = viewer.sWidth;
+  const newZoom = viewer.zoom - 10*dzoom;
+  const oldZoom = viewer.zoom;
+  const newHeight = rawHeight*100/newZoom;
+  const newWidth = rawWidth*100/newZoom;
+  const oldHeight = viewer.sHeight;
+  const oldWidth = viewer.sWidth;
   if (newZoom >= viewer.zoomLimit) {
-    zoom = newZoom;
+    viewer.zoom = newZoom;
     viewer.sHeight = newHeight;
     viewer.sWidth = newWidth;
   }
@@ -826,7 +823,7 @@ function render_info_display() {
   $('#frame').html(current_frame);
   $('#feature').html(mode.feature);
   $('#channel').html(mode.channel);
-  $('#zoom').html(`${zoom}%`);
+  $('#zoom').html(`${viewer.zoom}%`);
   $('#displayedX').html(`${Math.floor(viewer.sx)}-${Math.ceil(viewer.sx+viewer.sWidth)}`);
   $('#displayedY').html(`${Math.floor(viewer.sy)}-${Math.ceil(viewer.sy+viewer.sHeight)}`);
 
@@ -863,7 +860,7 @@ function render_edit_image(ctx) {
   ctx.imageSmoothingEnabled = true;
 
   // draw brushview on top of cells/annotations
-  brush.draw(ctx, viewer.sx, viewer.sy, viewer.sWidth, viewer.sHeight, scale*zoom/100);
+  brush.draw(ctx, viewer.sx, viewer.sy, viewer.sWidth, viewer.sHeight, scale*viewer.zoom/100);
 
   ctx.restore();
 }
@@ -1045,7 +1042,7 @@ function setCanvasDimensions(rawDims) {
   // dimensions need to maintain aspect ratio for drawing purposes
   dimensions = [scale * rawDims[0], scale * rawDims[1]];
 
-  zoom = 100;
+  viewer.zoom = 100;
 
   // set canvases size according to scale
   $('#canvas').get(0).width = dimensions[0] + 2 * padding;
@@ -1145,8 +1142,8 @@ function updateMousePos(x, y) {
 
   // convert to image indices, to use for actions and getting label
   if (cursor.inRange(canvasPosX, canvasPosY)) {
-    imgX = Math.floor((canvasPosX * 100 / (scale * zoom) + viewer.sx));
-    imgY = Math.floor((canvasPosY * 100 / (scale * zoom) + viewer.sy));
+    imgX = Math.floor((canvasPosX * 100 / (scale * viewer.zoom) + viewer.sx));
+    imgY = Math.floor((canvasPosY * 100 / (scale * viewer.zoom) + viewer.sy));
     brush.x = imgX;
     brush.y = imgY;
     // update brush preview
@@ -1166,8 +1163,8 @@ function updateMousePos(x, y) {
 function handle_mousemove(evt) {
   if (cursor.pressed && spacedown) {
     panCanvas(
-      evt.originalEvent.movementX * 100 / (zoom * scale),
-      evt.originalEvent.movementY * 100 / (zoom * scale)
+      evt.originalEvent.movementX * 100 / (viewer.zoom * scale),
+      evt.originalEvent.movementY * 100 / (viewer.zoom * scale)
     );
   }
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -712,24 +712,7 @@ function panCanvas(dx, dy) {
 }
 
 function changeZoom(dzoom) {
-  const newZoom = viewer.zoom - 10*dzoom;
-  const oldZoom = viewer.zoom;
-  const newHeight = rawHeight*100/newZoom;
-  const newWidth = rawWidth*100/newZoom;
-  const oldHeight = viewer.sHeight;
-  const oldWidth = viewer.sWidth;
-  if (newZoom >= viewer.zoomLimit) {
-    viewer.zoom = newZoom;
-    viewer.sHeight = newHeight;
-    viewer.sWidth = newWidth;
-  }
-  if (oldZoom !== newZoom) {
-    let propX = canvasPosX/dimensions[0];
-    let propY = canvasPosY/dimensions[1];
-    let dx = propX*(newWidth - oldWidth);
-    let dy = propY*(newHeight - oldHeight);
-    panCanvas(dx, dy);
-  }
+  viewer.changeZoom(dzoom, canvasPosX, canvasPosY);
   updateMousePos(_rawMouseX, _rawMouseY);
   render_image_display();
 }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1129,6 +1129,12 @@ function helper_brush_draw() {
 
 // input will typically be evt.offsetX, evt.offsetY (mouse events)
 function updateMousePos(x, y) {
+
+  // get old imgX and imgY
+  // run cursor.updatePos(x, y, viewer)
+  // check new imgX and imgY
+  // update brush if these have changed
+
   // store raw mouse position, in case of pan without mouse movement
   _rawMouseX = x;
   _rawMouseY = y;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -708,17 +708,6 @@ function changeZoom(dzoom) {
   render_image_display();
 }
 
-
-function label_under_mouse() {
-  let new_label;
-  if (cursor.inRange()) {
-    new_label = Math.abs(seg_array[cursor.imgY][cursor.imgX]); //check array value at mouse location
-  } else {
-    new_label = 0;
-  }
-  return new_label;
-}
-
 function render_highlight_info() {
   if (current_highlight) {
     $('#highlight').html("ON");
@@ -774,7 +763,10 @@ function render_edit_info() {
 }
 
 function render_cell_info() {
-  current_label = label_under_mouse();
+  // TODO: could also change to add seg_array as attribute of cursor object
+  // so that current_label becomes cursor.label and is updated on mouse movement,
+  // cursor.seg_array updated on new seg_array being loaded
+  current_label = cursor.getCurrentLabel(seg_array);
   if (current_label !== 0) {
     $('#label').html(current_label);
     let track = tracks[mode.feature][current_label.toString()];

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1313,7 +1313,6 @@ function start_caliban(filename) {
     waitForFinalEvent(function() {
       mode.clear();
       setCanvasDimensions(rawDimensions);
-      brush.scale = viewer.scale;
       cursor.scale = viewer.scale;
       brush.refreshView();
     }, 500, 'canvasResize');
@@ -1330,7 +1329,7 @@ function start_caliban(filename) {
   // define image onload cascade behavior, need rawHeight and rawWidth first
   adjuster = new ImageAdjuster(width=rawWidth, height=rawHeight,
                                rgb=rgb, channelMax=channelMax);
-  brush = new Brush(viewer.scale=scale, height=rawHeight, width=rawWidth, pad=padding);
+  brush = new Brush(height=rawHeight, width=rawWidth, pad=padding);
 
   adjuster.postCompImg.onload = render_image_display;
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -412,6 +412,7 @@ class Mode {
 
   handle_draw() {
     action("handle_draw", {
+      // TODO: getter for cursor.trace that stringifies it
       "trace": JSON.stringify(cursor.trace), // stringify array so it doesn't get messed up
       "target_value": brush.target, // value that we're overwriting
       "brush_value": brush.value, // we don't update caliban with edit_value, etc each time they change
@@ -419,6 +420,7 @@ class Mode {
       "erase": (brush.erase && !brush.conv),
       "frame": current_frame
     });
+    // TODO: cursor.clearTrace ?
     cursor.trace = [];
     if (this.kind !== Modes.drawing) {
       this.clear();
@@ -467,6 +469,7 @@ class Mode {
     return currentValue;
   }
 
+  // TODO: cursor.click(evt, mode) ?
   handle_mode_none_click(evt) {
     if (evt.altKey) {
       // alt+click
@@ -536,6 +539,8 @@ class Mode {
     }
   }
 
+  // TODO: storedClick1 and storedClick2? not a huge fan of the
+  // current way click locations get stored in mode object
   handle_mode_single_click(evt) {
     this.kind = Modes.multiple;
 
@@ -569,6 +574,9 @@ class Mode {
     };
   }
 
+  // TODO: lots of objects being used here, would be great to disentangle
+  // or at least move out of Mode class--should act on mode object and others
+  // but not sure this makes sense as a Mode method
   click(evt) {
     if (this.kind === Modes.prompt) {
       // hole fill or color picking options
@@ -637,6 +645,10 @@ let rgb;
 let rawWidth;
 let rawHeight;
 
+// TODO: move dimensions into cursor or viewer object?
+// raw image dimensions * screen scaling
+var dimensions;
+
 const padding = 5;
 
 var seg_array; // declare here so it is global var
@@ -650,7 +662,6 @@ var current_highlight;
 var max_frames;
 var feature_max;
 var channelMax;
-var dimensions;
 var tracks;
 let maxLabelsMap = new Map();
 var mode = new Mode(Modes.none, {});
@@ -792,6 +803,10 @@ function render_info_display() {
   $('#mode').html(mode.render());
 }
 
+// TODO for ctx.drawImage calls--write a wrapper for these?
+// they all use the same viewer attributes (and padding and dimension args)
+// to use all optional args for ctx.drawImage call
+// possibly a CalibanCanvas class that has ctx, padding, dimensions attributes
 function render_edit_image(ctx) {
   if (rgb && rendering_raw) {
     render_raw_image(ctx);
@@ -846,6 +861,7 @@ function render_annotation_image(ctx) {
 function render_image_display() {
   let ctx = $('#canvas').get(0).getContext('2d');
   ctx.imageSmoothingEnabled = false;
+  // TODO: is there a corresponding ctx.restore to match this ctx.save?
   ctx.save();
   ctx.clearRect(0, 0, 2 * padding + dimensions[0], 2 * padding + dimensions[1]);
 
@@ -896,6 +912,8 @@ function load_file(file) {
 
       viewer = new CanvasView(width=rawWidth, height=rawHeight);
 
+      // TODO: does this need to be in load_file?
+      // we could probably call it right after load_file to decouple them better
       setCanvasDimensions(rawDimensions);
 
       tracks = payload.tracks; // tracks payload is dict

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -412,14 +412,14 @@ class Mode {
 
   handle_draw() {
     action("handle_draw", {
-      "trace": JSON.stringify(mouse_trace), // stringify array so it doesn't get messed up
+      "trace": JSON.stringify(cursor.trace), // stringify array so it doesn't get messed up
       "target_value": brush.target, // value that we're overwriting
       "brush_value": brush.value, // we don't update caliban with edit_value, etc each time they change
       "brush_size": brush.size, // so we need to pass them in as args
       "erase": (brush.erase && !brush.conv),
       "frame": current_frame
     });
-    mouse_trace = [];
+    cursor.trace = [];
     if (this.kind !== Modes.drawing) {
       this.clear();
     }
@@ -682,7 +682,6 @@ var answer = "(SPACE=YES / ESC=NO)";
 let spacedown = false;
 var tooltype = 'draw';
 var project_id;
-let mouse_trace = [];
 
 var brush;
 var adjust;
@@ -1118,7 +1117,7 @@ function handle_mousedown(evt) {
           brush.threshY = imgY;
         } else if (mode.kind !== Modes.prompt) {
           // not if turning on conv brush
-          mouse_trace.push([imgY, imgX]);
+          cursor.trace.push([imgY, imgX]);
         }
       }
     }
@@ -1129,7 +1128,7 @@ function helper_brush_draw() {
   if (cursor.pressed && !spacedown) {
     // update mouse_trace, but not if turning on conv brush
     if (mode.kind !== Modes.prompt) {
-      mouse_trace.push([imgY, imgX]);
+      cursor.trace.push([imgY, imgX]);
     }
   } else {
     brush.clearView();

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -640,9 +640,6 @@ let rawHeight;
 const padding = 5;
 
 // mouse position variables
-// adjusted for padding
-let canvasPosX;
-let canvasPosY;
 // coordinates in original image (used for actions, labels, etc)
 let imgX;
 let imgY;
@@ -709,7 +706,7 @@ function panCanvas(dx, dy) {
 }
 
 function changeZoom(dzoom) {
-  viewer.changeZoom(dzoom, canvasPosX, canvasPosY);
+  viewer.changeZoom(dzoom, cursor.canvasPosX, cursor.canvasPosY);
   updateMousePos(cursor.rawX, cursor.rawY);
   render_image_display();
 }
@@ -717,7 +714,7 @@ function changeZoom(dzoom) {
 
 function label_under_mouse() {
   let new_label;
-  if (cursor.inRange(canvasPosX, canvasPosY)) {
+  if (cursor.inRange(cursor.canvasPosX, cursor.canvasPosY)) {
     new_label = Math.abs(seg_array[imgY][imgX]); //check array value at mouse location
   } else {
     new_label = 0;
@@ -1049,13 +1046,13 @@ function updateMousePos(x, y) {
   cursor.rawY = y;
 
   // convert to viewing pane position, to check whether to access label underneath
-  canvasPosX = x - padding;
-  canvasPosY = y - padding;
+  cursor.canvasPosX = x - padding;
+  cursor.canvasPosY = y - padding;
 
   // convert to image indices, to use for actions and getting label
-  if (cursor.inRange(canvasPosX, canvasPosY)) {
-    imgX = Math.floor((canvasPosX * 100 / (viewer.scale * viewer.zoom) + viewer.sx));
-    imgY = Math.floor((canvasPosY * 100 / (viewer.scale * viewer.zoom) + viewer.sy));
+  if (cursor.inRange(cursor.canvasPosX, cursor.canvasPosY)) {
+    imgX = Math.floor((cursor.canvasPosX * 100 / (viewer.scale * viewer.zoom) + viewer.sx));
+    imgY = Math.floor((cursor.canvasPosY * 100 / (viewer.scale * viewer.zoom) + viewer.sy));
     brush.x = imgX;
     brush.y = imgY;
     // update brush preview

--- a/browser/templates/base.html
+++ b/browser/templates/base.html
@@ -68,7 +68,7 @@
     <!-- Load Custom JavaScript -->
     <script type="text/javascript" src="{{ url_for('static', filename='js/adjust.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/brush.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/cursor.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/canvas.js') }}"></script>
     {% block extraJs %}
     {% endblock %}
 

--- a/browser/templates/base.html
+++ b/browser/templates/base.html
@@ -68,6 +68,7 @@
     <!-- Load Custom JavaScript -->
     <script type="text/javascript" src="{{ url_for('static', filename='js/adjust.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/brush.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/cursor.js') }}"></script>
     {% block extraJs %}
     {% endblock %}
 

--- a/browser/templates/tool.html
+++ b/browser/templates/tool.html
@@ -79,7 +79,7 @@
       document.getElementById("output").classList.remove("hide");
     });
   }
-  start_caliban("{{filename}}");
+  startCaliban("{{filename}}", settings);
 </script>
 <!-- END CALIBAN FUNCTION CALL -->
 {%- endblock -%}


### PR DESCRIPTION
Make browser js code more modular (and reduce globally scoped variables) by grouping some functions and variables into classes. This PR introduces a cursor class to keep track of mouse position on canvas (and related information and methods), and a viewing window class to handle panning, zooming, drawing borders around, and keeping track of the currently displayed portion of the image.

Originally intended to substantially clean up mouse events, but these may be trickier as they are entangled with `Mode` behavior. Hoping to close #158 by refining the behavior of `mouse_trace` (now `cursor.trace`).