### PR TITLE
Remove cursor visibility toggle from desktop version

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ Annotation mode focuses on using an adjustable brush to modify annotations on a 
 
 *j* - apply adaptive histogram equalization to raw image (viewing raw image or in pixel editor)
 
-*v* - switch between showing and hiding cursor
-
 *f* - cycle between different annotations when no labels are selected (label-editing mode)
 
 *c* - cycle between different channels when no labels are selected (label-editing mode)

--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -168,9 +168,6 @@ class CalibanWindow:
         self.key_states = key.KeyStateHandler()
         self.window.push_handlers(self.key_states)
 
-        # start with cursor visible, but this can be toggled
-        self.mouse_visible = True
-
         # start in label-editing mode
         self.edit_mode = False
         # start with display showing annotations
@@ -2112,7 +2109,6 @@ class TrackReview(CalibanWindow):
         Keybinds:
             a or left arrow key: view previous frame
             d or right arrow key: view next frame
-            v: toggle cursor visibility
             h: toggle highlighting
             escape: clear selection
             minus: zoom out
@@ -2145,12 +2141,6 @@ class TrackReview(CalibanWindow):
                 if self.edit_mode and not self.hide_annotations:
                     self.helper_update_composite()
                 self.update_image = True
-
-        # TOGGLE CURSOR VISIBILITY
-        # most useful in edit mode, but inconvenient if can't be turned back on elsewhere
-        elif symbol == key.V:
-            self.mouse_visible = not self.mouse_visible
-            self.window.set_mouse_visible(self.mouse_visible)
 
         # TOGGLE HIGHLIGHT
         # note: shift+H is conditional keybind elsewhere
@@ -3384,7 +3374,6 @@ class ZStackReview(CalibanWindow):
         Keybinds:
             a or left arrow key: view previous frame
             d or right arrow key: view next frame
-            v: toggle cursor visibility
             h: toggle highlighting
             escape: clear selection or cancel action
             minus: zoom out
@@ -3417,12 +3406,6 @@ class ZStackReview(CalibanWindow):
                 if self.edit_mode and not self.hide_annotations:
                     self.helper_update_composite()
                 self.update_image = True
-
-        # TOGGLE CURSOR VISIBILITY
-        # most useful in edit mode, but inconvenient if can't be turned back on elsewhere
-        elif symbol == key.V:
-            self.mouse_visible = not self.mouse_visible
-            self.window.set_mouse_visible(self.mouse_visible)
 
         # TOGGLE HIGHLIGHT
         # note: shift+H is conditional keybind elsewhere


### PR DESCRIPTION
Closes #185. Option to toggle visibility used to be more useful when pixel-editing mode was in development. We no longer need the option, so removing it will free up a keybind and make desktop caliban slightly less complex.

- remove keybind from ZStackReview, TrackReview
- remove mention of keybind from readme