### PR TITLE
bugfix (update displayed info when mouse moves)

### DIFF
--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1030,6 +1030,7 @@ function handleMousemove(evt) {
     }
   }
   updateMousePos(evt.offsetX, evt.offsetY);
+  render_info_display();
 }
 
 // handles end of click&drag (different from click())


### PR DESCRIPTION
Should not have been removed in earlier changes. When the mouse moves, the underlying image may not change but the specific info displayed often does.