### PR TITLE
add a white outline to highlighted pixel-editing label

### DIFF
--- a/browser/static/js/adjust.js
+++ b/browser/static/js/adjust.js
@@ -285,7 +285,7 @@ class ImageAdjuster {
     this.compositedImg.src = this.canvas.toDataURL();
   }
 
-  // apply outlines, transparent highlighting
+  // apply white (and sometimes red) opaque outlines around cells, if needed
   postCompAdjust(segArray, editMode, brush, currentHighlight) {
     // draw compositedImg so we can extract image data
     this.ctx.clearRect(0, 0, this.width, this.height);
@@ -300,10 +300,13 @@ class ImageAdjuster {
       redOutline = true;
       r1 = brush.target;
     }
+    // white outline for conversion brush drawing value
     if (editMode && brush.conv && brush.value !== -1) {
       singleOutline = true;
       o1 = brush.value;
     }
+    // add an outline around the currently highlighted cell, if there is one
+    // but only if the brush isn't set to conversion brush mode
     if (editMode && currentHighlight && !brush.conv) {
       singleOutline = true;
       o1 = brush.value;

--- a/browser/static/js/adjust.js
+++ b/browser/static/js/adjust.js
@@ -286,7 +286,7 @@ class ImageAdjuster {
   }
 
   // apply outlines, transparent highlighting
-  postCompAdjust(segArray, editMode, brush) {
+  postCompAdjust(segArray, editMode, brush, currentHighlight) {
     // draw compositedImg so we can extract image data
     this.ctx.clearRect(0, 0, this.width, this.height);
     this.ctx.drawImage(this.compositedImg, 0, 0, this.width, this.height);
@@ -301,6 +301,10 @@ class ImageAdjuster {
       r1 = brush.target;
     }
     if (editMode && brush.conv && brush.value !== -1) {
+      singleOutline = true;
+      o1 = brush.value;
+    }
+    if (editMode && currentHighlight && !brush.conv) {
       singleOutline = true;
       o1 = brush.value;
     }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1172,7 +1172,7 @@ function startCaliban(filename, settings) {
       adjuster.contrastedRaw.onload = () => adjuster.preCompRawAdjust();
       adjuster.preCompRaw.onload = () => adjuster.rawAdjust(state.segArray, current_highlight, edit_mode, brush, mode);
       adjuster.preCompSeg.onload = () => adjuster.segAdjust(state.segArray, current_highlight, edit_mode, brush, mode);
-      adjuster.compositedImg.onload = () => adjuster.postCompAdjust(state.segArray, edit_mode, brush);
+      adjuster.compositedImg.onload = () => adjuster.postCompAdjust(state.segArray, edit_mode, brush, current_highlight);
     }
 
     adjuster.postCompImg.onload = render_image_display;


### PR DESCRIPTION
Add a white outline to highlighted label in non-rgb pixel-editing mode to help distinguish labels from each other. Highlighting already recolored current label to red, but the semi-translucency of the label could still make it a little difficult to see exactly where the boundaries were. This change makes the highlighting behavior more similar to desktop version (label is outlined but not changed to red) and to how the conversion brush labels are shown in non-rgb pixel-editing mode.

Example:
![image](https://user-images.githubusercontent.com/45578681/91768134-0c293080-eb92-11ea-9d15-cd546b6aec9c.png)
